### PR TITLE
Change `html/template` to `text/template`

### DIFF
--- a/package/moq/moq.go
+++ b/package/moq/moq.go
@@ -8,10 +8,10 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
-	"html/template"
 	"io"
 	"os"
 	"strings"
+	"text/template"
 )
 
 // Mocker can generate mock structs.

--- a/package/moq/moq_test.go
+++ b/package/moq/moq_test.go
@@ -115,7 +115,7 @@ func TestNothingToReturn(t *testing.T) {
 	}
 }
 
-func TestChannelsName(t *testing.T) {
+func TestChannelNames(t *testing.T) {
 	m, err := New("testdata/channels", "")
 	if err != nil {
 		t.Errorf("moq.New: %s", err)

--- a/package/moq/moq_test.go
+++ b/package/moq/moq_test.go
@@ -114,3 +114,24 @@ func TestNothingToReturn(t *testing.T) {
 		}
 	}
 }
+
+func TestChannelsName(t *testing.T) {
+	m, err := New("testdata/channels", "")
+	if err != nil {
+		t.Errorf("moq.New: %s", err)
+	}
+	var buf bytes.Buffer
+	err = m.Mock(&buf, "Queuer")
+	if err != nil {
+		t.Errorf("m.Mock: %s", err)
+	}
+	s := buf.String()
+	var strs = []string{
+		"func (mock *QueuerMock) Sub(topic string) (<-chan Queue, error)",
+	}
+	for _, str := range strs {
+		if !strings.Contains(s, str) {
+			t.Errorf("expected by missing: \"%s\"", str)
+		}
+	}
+}

--- a/package/moq/testdata/channels/example.go
+++ b/package/moq/testdata/channels/example.go
@@ -1,0 +1,7 @@
+package channels
+
+type Queue []string
+
+type Queuer interface {
+	Sub(topic string) (<-chan Queue, error)
+}


### PR DESCRIPTION
This fixes #11, where `<` character was escaped, e.g. in `chan<- struct{}`.