### PR TITLE
[PATCH] Made tests independent from package path

### DIFF
--- a/pkg/moq/moq_test.go
+++ b/pkg/moq/moq_test.go
@@ -210,7 +210,7 @@ func TestDotImports(t *testing.T) {
 		t.Errorf("mock error: %s", err)
 	}
 	s := buf.String()
-	if !strings.Contains(s, `"github.com/matryer/moq/pkg/moq/testpackages/dotimport"`) {
+	if !strings.Contains(s, `/moq/pkg/moq/testpackages/dotimport"`) {
 		t.Error("contains invalid dot import")
 	}
 }


### PR DESCRIPTION
The test case checked for a whole package path, which should exist in a generated moq file, but that failed for obvious reasons in forks.

I just removed the part, which is different in the forks to pass the test. If you don't think, that this is sufficient, I can change it.