### PR TITLE
Resolve name shadowing between imports and params

### DIFF
--- a/pkg/moq/moq.go
+++ b/pkg/moq/moq.go
@@ -111,6 +111,8 @@ func (m *Mocker) Mock(w io.Writer, names ...string) error {
 
 	mocksMethods := false
 
+	paramCache := make(map[string][]*param)
+
 	tpkg := m.srcPkg.Types
 	for _, name := range names {
 		n, mockName := parseInterfaceName(name)
@@ -135,6 +137,10 @@ func (m *Mocker) Mock(w io.Writer, names ...string) error {
 			}
 			obj.Methods = append(obj.Methods, method)
 			method.Params, method.Returns = m.extractArgs(sig)
+
+			for _, param := range method.Params {
+				paramCache[param.Name] = append(paramCache[param.Name], param)
+			}
 		}
 		doc.Objects = append(doc.Objects, obj)
 	}
@@ -150,6 +156,18 @@ func (m *Mocker) Mock(w io.Writer, names ...string) error {
 	if tpkg.Name() != m.pkgName {
 		doc.SourcePackagePrefix = tpkg.Name() + "."
 		doc.Imports = append(doc.Imports, stripVendorPath(tpkg.Path()))
+	}
+
+	// try to detect naming conflicts; we aren't necessarily in the same
+	// package setup as the final mocks, so don't error out- best effort only.
+	conf := packages.Config{Mode: packages.NeedName}
+	pkgs, _ := packages.Load(&conf, doc.Imports...)
+	for _, pkg := range pkgs {
+		if params, hasConflict := paramCache[pkg.Name]; hasConflict {
+			for _, param := range params {
+				param.LocalName = fmt.Sprintf("%sMoqParam", param.LocalName)
+			}
+		}
 	}
 
 	var buf bytes.Buffer
@@ -205,7 +223,7 @@ func (m *Mocker) buildParam(v *types.Var, fallbackName string) *param {
 		name = fallbackName
 	}
 	typ := types.TypeString(v.Type(), m.packageQualifier)
-	return &param{Name: name, Type: typ}
+	return &param{Name: name, LocalName: name, Type: typ}
 }
 
 func pkgInfoFromPath(srcDir string, mode packages.LoadMode) (*packages.Package, error) {
@@ -281,20 +299,21 @@ func (m *method) ReturnArglist() string {
 }
 
 type param struct {
-	Name     string
-	Type     string
-	Variadic bool
+	Name      string
+	LocalName string
+	Type      string
+	Variadic  bool
 }
 
 func (p param) String() string {
-	return fmt.Sprintf("%s %s", p.Name, p.TypeString())
+	return fmt.Sprintf("%s %s", p.LocalName, p.TypeString())
 }
 
 func (p param) CallName() string {
 	if p.Variadic {
-		return p.Name + "..."
+		return p.LocalName + "..."
 	}
-	return p.Name
+	return p.LocalName
 }
 
 func (p param) TypeString() string {

--- a/pkg/moq/moq_test.go
+++ b/pkg/moq/moq_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -500,30 +499,19 @@ func TestEmptyInterface(t *testing.T) {
 	}
 }
 
+func helperExec(t *testing.T, args []string, dir string) []byte {
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Exec: %s; Output:\n%s\n", err, output)
+	}
+	return output
+}
+
 func TestGoGenerateVendoredPackages(t *testing.T) {
-	cmd := exec.Command("go", "generate", "./...")
-	cmd.Dir = "testpackages/gogenvendoring"
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		t.Errorf("StdoutPipe: %s", err)
-	}
-	defer stdout.Close()
-	err = cmd.Start()
-	if err != nil {
-		t.Errorf("Start: %s", err)
-	}
-	buf := bytes.NewBuffer(nil)
-	io.Copy(buf, stdout)
-	err = cmd.Wait()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			t.Errorf("Wait: %s %s", exitErr, string(exitErr.Stderr))
-		} else {
-			t.Errorf("Wait: %s", err)
-		}
-	}
-	s := buf.String()
-	if strings.Contains(s, `vendor/`) {
+	output := helperExec(t, []string{"go", "generate", "./..."}, "testpackages/gogenvendoring")
+	if bytes.Contains(output, []byte(`vendor/`)) {
 		t.Error("contains vendor directory in import path")
 	}
 }
@@ -553,4 +541,32 @@ func normalize(d []byte) []byte {
 	// replace CF \r (mac) with LF \n (unix)
 	d = bytes.Replace(d, []byte{13}, []byte{10}, -1)
 	return d
+}
+
+func TestParamShadowsImport(t *testing.T) {
+	m, err := New(Config{SrcDir: "testpackages/shadow", PkgName: "gen"})
+	if err != nil {
+		t.Fatalf("moq.New: %s", err)
+	}
+
+	genDir := "./testpackages/shadow/gen"
+	err = os.MkdirAll(genDir, 0777)
+	if err != nil {
+		t.Fatalf("mkdir: %s", err)
+	}
+	defer os.Remove(genDir)
+
+	f, err := os.Create(filepath.Join(genDir, "shadowmock.go"))
+	if err != nil {
+		t.Fatalf("failed to create shadowmock: %s", err)
+	}
+	defer f.Close()
+	defer os.Remove(f.Name())
+
+	err = m.Mock(f, "Shadower")
+	if err != nil {
+		t.Fatalf("mock error: %s", err)
+	}
+
+	helperExec(t, []string{"go", "vet", genDir}, "")
 }

--- a/pkg/moq/template.go
+++ b/pkg/moq/template.go
@@ -72,7 +72,7 @@ func (mock *{{$obj.MockName}}) {{.Name}}({{.Arglist}}) {{.ReturnArglist}} {
 		{{- end }}
 	}{
 		{{- range .Params }}
-		{{ .Name | Exported }}: {{ .Name }},
+		{{ .Name | Exported }}: {{ .LocalName }},
 		{{- end }}
 	}
 	lock{{$obj.MockName}}{{.Name}}.Lock()

--- a/pkg/moq/testpackages/shadow/example.go
+++ b/pkg/moq/testpackages/shadow/example.go
@@ -1,0 +1,11 @@
+package shadow
+
+import (
+	"io"
+)
+
+// Shadower is an interface, with a method, with a parameter whose name shadows
+// an import name
+type Shadower interface {
+	Shadow(io io.Reader)
+}


### PR DESCRIPTION
If the interface to be mocked requires an import that is shadowed by a
param with the same name, it's unlikely to be a problem for the upstream
interface (and thus go undetected), but it causes moq to generate
invalid code.

Example in the wild:
https://github.com/kubernetes/helm/blob/534193640179fe3c9ffc3012a7bc4e8b23fbe832/pkg/helm/interface.go#L28 (the conflict is between the `chart` param and the `chart` import)