### PR TITLE
Add Todo flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 	var (
 		outFile = flag.String("out", "", "output file (default stdout)")
 		pkgName = flag.String("pkg", "", "package name (default will infer)")
+		addTodo = flag.Bool("todo", true, "Whether or not to include TODO comments in generated code")
 	)
 	flag.Usage = func() {
 		fmt.Println(`moq [flags] destination interface [interface2 [interface3 [...]]]`)
@@ -44,7 +45,7 @@ func main() {
 	if len(*outFile) > 0 {
 		out = &buf
 	}
-	m, err := moq.New(destination, *pkgName)
+	m, err := moq.New(destination, *pkgName, *addTodo)
 	if err != nil {
 		return
 	}

--- a/pkg/moq/moq_test.go
+++ b/pkg/moq/moq_test.go
@@ -42,6 +42,40 @@ func TestMoq(t *testing.T) {
 	}
 }
 
+func TestTodoIncluded(t *testing.T) {
+	m, err := New("testpackages/example", "", true)
+	if err != nil {
+		t.Fatalf("moq.New: %s", err)
+	}
+	var buf bytes.Buffer
+	err = m.Mock(&buf, "PersonStore")
+	if err != nil {
+		t.Errorf("m.Mock: %s", err)
+	}
+	s := buf.String()
+	// assertions of things that should be mentioned
+	if !strings.Contains(s, "TODO") {
+		t.Errorf("Expected TODO comments not to be included")
+	}
+}
+
+func TestTodoNotIncluded(t *testing.T) {
+	m, err := New("testpackages/example", "", false)
+	if err != nil {
+		t.Fatalf("moq.New: %s", err)
+	}
+	var buf bytes.Buffer
+	err = m.Mock(&buf, "PersonStore")
+	if err != nil {
+		t.Errorf("m.Mock: %s", err)
+	}
+	s := buf.String()
+	// assertions of things that should be mentioned
+	if strings.Contains(s, "TODO") {
+		t.Errorf("Expected TODO comments to be included")
+	}
+}
+
 func TestMoqExplicitPackage(t *testing.T) {
 	m, err := New("testpackages/example", "different", true)
 	if err != nil {

--- a/pkg/moq/moq_test.go
+++ b/pkg/moq/moq_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMoq(t *testing.T) {
-	m, err := New("testpackages/example", "")
+	m, err := New("testpackages/example", "", true)
 	if err != nil {
 		t.Fatalf("moq.New: %s", err)
 	}
@@ -43,7 +43,7 @@ func TestMoq(t *testing.T) {
 }
 
 func TestMoqExplicitPackage(t *testing.T) {
-	m, err := New("testpackages/example", "different")
+	m, err := New("testpackages/example", "different", true)
 	if err != nil {
 		t.Fatalf("moq.New: %s", err)
 	}
@@ -73,7 +73,7 @@ func TestMoqExplicitPackage(t *testing.T) {
 // expected.
 // see https://github.com/matryer/moq/issues/5
 func TestVariadicArguments(t *testing.T) {
-	m, err := New("testpackages/variadic", "")
+	m, err := New("testpackages/variadic", "", true)
 	if err != nil {
 		t.Fatalf("moq.New: %s", err)
 	}
@@ -98,7 +98,7 @@ func TestVariadicArguments(t *testing.T) {
 }
 
 func TestNothingToReturn(t *testing.T) {
-	m, err := New("testpackages/example", "")
+	m, err := New("testpackages/example", "", true)
 	if err != nil {
 		t.Fatalf("moq.New: %s", err)
 	}
@@ -123,7 +123,7 @@ func TestNothingToReturn(t *testing.T) {
 }
 
 func TestChannelNames(t *testing.T) {
-	m, err := New("testpackages/channels", "")
+	m, err := New("testpackages/channels", "", true)
 	if err != nil {
 		t.Fatalf("moq.New: %s", err)
 	}
@@ -144,7 +144,7 @@ func TestChannelNames(t *testing.T) {
 }
 
 func TestImports(t *testing.T) {
-	m, err := New("testpackages/imports/two", "")
+	m, err := New("testpackages/imports/two", "", true)
 	if err != nil {
 		t.Fatalf("moq.New: %s", err)
 	}
@@ -176,7 +176,7 @@ func TestTemplateFuncs(t *testing.T) {
 }
 
 func TestVendoredPackages(t *testing.T) {
-	m, err := New("testpackages/vendoring/user", "")
+	m, err := New("testpackages/vendoring/user", "", true)
 	if err != nil {
 		t.Fatalf("moq.New: %s", err)
 	}
@@ -213,7 +213,7 @@ func TestDotImports(t *testing.T) {
 			t.Errorf("Chdir back: %s", err)
 		}
 	}()
-	m, err := New(".", "moqtest_test")
+	m, err := New(".", "moqtest_test", true)
 	if err != nil {
 		t.Fatalf("moq.New: %s", err)
 	}
@@ -229,7 +229,7 @@ func TestDotImports(t *testing.T) {
 }
 
 func TestEmptyInterface(t *testing.T) {
-	m, err := New("testpackages/emptyinterface", "")
+	m, err := New("testpackages/emptyinterface", "", true)
 	if err != nil {
 		t.Fatalf("moq.New: %s", err)
 	}

--- a/pkg/moq/template.go
+++ b/pkg/moq/template.go
@@ -29,11 +29,11 @@ var (
 //         // make and configure a mocked {{.InterfaceName}}
 //         mocked{{.InterfaceName}} := &{{.InterfaceName}}Mock{ {{ range .Methods }}
 //             {{.Name}}Func: func({{ .Arglist }}) {{.ReturnArglist}} {
-// 	               panic("TODO: mock out the {{.Name}} method")
+// 	               panic("{{if .AddTodo}}TODO: {{end}}Mock out the {{.Name}} method")
 //             },{{- end }}
 //         }
 //
-//         // TODO: use mocked{{.InterfaceName}} in code that requires {{.InterfaceName}}
+//         // {{if .AddTodo}}TODO: {{end}}Use mocked{{.InterfaceName}} in code that requires {{.InterfaceName}}
 //         //       and then make assertions.
 //
 //     }

--- a/pkg/moq/template.go
+++ b/pkg/moq/template.go
@@ -34,7 +34,7 @@ var (
 //         }
 //
 //         // {{if .AddTodo}}TODO: {{end}}Use mocked{{.InterfaceName}} in code that requires {{.InterfaceName}}
-//         //       and then make assertions.
+//         // {{if .AddTodo}}      {{end}}and then make assertions.
 //
 //     }
 type {{.InterfaceName}}Mock struct {


### PR DESCRIPTION
Adds a boolean flag called `todo`  which defaults to `true`. If it's set to true `// TODO:` flags will be included in the generated code. Otherwise they will not.

Resolves https://github.com/matryer/moq/issues/56