### PR TITLE
 Use golang.org/x/tools/go/packages instead of loader 

### DIFF
--- a/pkg/moq/moq.go
+++ b/pkg/moq/moq.go
@@ -231,7 +231,7 @@ func pkgInfoFromPath(src string) (*packages.Package, error) {
 	pkgFull := stripGopath(abs)
 
 	conf := packages.Config{
-		Mode: packages.LoadAllSyntax,
+		Mode: packages.LoadSyntax,
 		Dir:  src,
 	}
 	foundPackages, err := packages.Load(&conf, pkgFull)


### PR DESCRIPTION
The `packages` library uses the go build cache to get the info about the AST. This results in insane speedups when `moq` is used on large codebases.

Our `moq` calls went from ~16s to less than 1s.