### PR TITLE
Test on supported versions of Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ language: go
 sudo: false
 
 go:
-  - 1.7.x
-  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
   - tip
 
 before_install:
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
 
 before_script:
   - go vet ./...


### PR DESCRIPTION
Golint won't even install currently.

Also change the `go get` command to use `golang.org/x/lint/golint`.

Fixes #75 