### PR TITLE
Move global mutex to inside the mocked struct

### DIFF
--- a/example/mockpersonstore_test.go
+++ b/example/mockpersonstore_test.go
@@ -8,15 +8,6 @@ import (
 	"sync"
 )
 
-var (
-	lockPersonStoreMockCreate sync.RWMutex
-	lockPersonStoreMockGet    sync.RWMutex
-)
-
-// Ensure, that PersonStoreMock does implement PersonStore.
-// If this is not the case, regenerate this file with moq.
-var _ PersonStore = &PersonStoreMock{}
-
 // PersonStoreMock is a mock implementation of PersonStore.
 //
 //     func TestSomethingThatUsesPersonStore(t *testing.T) {
@@ -61,6 +52,8 @@ type PersonStoreMock struct {
 			ID string
 		}
 	}
+	lockPersonStoreMockCreate sync.RWMutex
+	lockPersonStoreMockGet    sync.RWMutex
 }
 
 // Create calls CreateFunc.
@@ -77,9 +70,9 @@ func (mock *PersonStoreMock) Create(ctx context.Context, person *Person, confirm
 		Person:  person,
 		Confirm: confirm,
 	}
-	lockPersonStoreMockCreate.Lock()
+	mock.lockPersonStoreMockCreate.Lock()
 	mock.calls.Create = append(mock.calls.Create, callInfo)
-	lockPersonStoreMockCreate.Unlock()
+	mock.lockPersonStoreMockCreate.Unlock()
 	return mock.CreateFunc(ctx, person, confirm)
 }
 
@@ -96,9 +89,9 @@ func (mock *PersonStoreMock) CreateCalls() []struct {
 		Person  *Person
 		Confirm bool
 	}
-	lockPersonStoreMockCreate.RLock()
+	mock.lockPersonStoreMockCreate.RLock()
 	calls = mock.calls.Create
-	lockPersonStoreMockCreate.RUnlock()
+	mock.lockPersonStoreMockCreate.RUnlock()
 	return calls
 }
 
@@ -114,9 +107,9 @@ func (mock *PersonStoreMock) Get(ctx context.Context, id string) (*Person, error
 		Ctx: ctx,
 		ID:  id,
 	}
-	lockPersonStoreMockGet.Lock()
+	mock.lockPersonStoreMockGet.Lock()
 	mock.calls.Get = append(mock.calls.Get, callInfo)
-	lockPersonStoreMockGet.Unlock()
+	mock.lockPersonStoreMockGet.Unlock()
 	return mock.GetFunc(ctx, id)
 }
 
@@ -131,8 +124,8 @@ func (mock *PersonStoreMock) GetCalls() []struct {
 		Ctx context.Context
 		ID  string
 	}
-	lockPersonStoreMockGet.RLock()
+	mock.lockPersonStoreMockGet.RLock()
 	calls = mock.calls.Get
-	lockPersonStoreMockGet.RUnlock()
+	mock.lockPersonStoreMockGet.RUnlock()
 	return calls
 }

--- a/generate/generated.go
+++ b/generate/generated.go
@@ -7,16 +7,6 @@ import (
 	"sync"
 )
 
-var (
-	lockMyInterfaceMockOne   sync.RWMutex
-	lockMyInterfaceMockThree sync.RWMutex
-	lockMyInterfaceMockTwo   sync.RWMutex
-)
-
-// Ensure, that MyInterfaceMock does implement MyInterface.
-// If this is not the case, regenerate this file with moq.
-var _ MyInterface = &MyInterfaceMock{}
-
 // MyInterfaceMock is a mock implementation of MyInterface.
 //
 //     func TestSomethingThatUsesMyInterface(t *testing.T) {
@@ -60,6 +50,9 @@ type MyInterfaceMock struct {
 		Two []struct {
 		}
 	}
+	lockMyInterfaceMockOne   sync.RWMutex
+	lockMyInterfaceMockThree sync.RWMutex
+	lockMyInterfaceMockTwo   sync.RWMutex
 }
 
 // One calls OneFunc.
@@ -69,9 +62,9 @@ func (mock *MyInterfaceMock) One() bool {
 	}
 	callInfo := struct {
 	}{}
-	lockMyInterfaceMockOne.Lock()
+	mock.lockMyInterfaceMockOne.Lock()
 	mock.calls.One = append(mock.calls.One, callInfo)
-	lockMyInterfaceMockOne.Unlock()
+	mock.lockMyInterfaceMockOne.Unlock()
 	return mock.OneFunc()
 }
 
@@ -82,9 +75,9 @@ func (mock *MyInterfaceMock) OneCalls() []struct {
 } {
 	var calls []struct {
 	}
-	lockMyInterfaceMockOne.RLock()
+	mock.lockMyInterfaceMockOne.RLock()
 	calls = mock.calls.One
-	lockMyInterfaceMockOne.RUnlock()
+	mock.lockMyInterfaceMockOne.RUnlock()
 	return calls
 }
 
@@ -95,9 +88,9 @@ func (mock *MyInterfaceMock) Three() string {
 	}
 	callInfo := struct {
 	}{}
-	lockMyInterfaceMockThree.Lock()
+	mock.lockMyInterfaceMockThree.Lock()
 	mock.calls.Three = append(mock.calls.Three, callInfo)
-	lockMyInterfaceMockThree.Unlock()
+	mock.lockMyInterfaceMockThree.Unlock()
 	return mock.ThreeFunc()
 }
 
@@ -108,9 +101,9 @@ func (mock *MyInterfaceMock) ThreeCalls() []struct {
 } {
 	var calls []struct {
 	}
-	lockMyInterfaceMockThree.RLock()
+	mock.lockMyInterfaceMockThree.RLock()
 	calls = mock.calls.Three
-	lockMyInterfaceMockThree.RUnlock()
+	mock.lockMyInterfaceMockThree.RUnlock()
 	return calls
 }
 
@@ -121,9 +114,9 @@ func (mock *MyInterfaceMock) Two() int {
 	}
 	callInfo := struct {
 	}{}
-	lockMyInterfaceMockTwo.Lock()
+	mock.lockMyInterfaceMockTwo.Lock()
 	mock.calls.Two = append(mock.calls.Two, callInfo)
-	lockMyInterfaceMockTwo.Unlock()
+	mock.lockMyInterfaceMockTwo.Unlock()
 	return mock.TwoFunc()
 }
 
@@ -134,8 +127,8 @@ func (mock *MyInterfaceMock) TwoCalls() []struct {
 } {
 	var calls []struct {
 	}
-	lockMyInterfaceMockTwo.RLock()
+	mock.lockMyInterfaceMockTwo.RLock()
 	calls = mock.calls.Two
-	lockMyInterfaceMockTwo.RUnlock()
+	mock.lockMyInterfaceMockTwo.RUnlock()
 	return calls
 }

--- a/pkg/moq/template.go
+++ b/pkg/moq/template.go
@@ -17,16 +17,6 @@ import (
 )
 
 {{ range $i, $obj := .Objects -}}
-var (
-{{- range .Methods }}
-	lock{{$obj.InterfaceName}}Mock{{.Name}}	sync.RWMutex
-{{- end }}
-)
-
-// Ensure, that {{.InterfaceName}}Mock does implement {{.InterfaceName}}.
-// If this is not the case, regenerate this file with moq.
-var _ {{$sourcePackagePrefix}}{{.InterfaceName}} = &{{.InterfaceName}}Mock{}
-
 // {{.InterfaceName}}Mock is a mock implementation of {{.InterfaceName}}.
 //
 //     func TestSomethingThatUses{{.InterfaceName}}(t *testing.T) {
@@ -59,6 +49,10 @@ type {{.InterfaceName}}Mock struct {
 		}
 {{- end }}
 	}
+
+{{- range .Methods }}
+	lock{{$obj.InterfaceName}}Mock{{.Name}}	sync.RWMutex
+{{- end }}
 }
 {{ range .Methods }}
 // {{.Name}} calls {{.Name}}Func.
@@ -75,9 +69,9 @@ func (mock *{{$obj.InterfaceName}}Mock) {{.Name}}({{.Arglist}}) {{.ReturnArglist
 		{{ .Name | Exported }}: {{ .Name }},
 		{{- end }}
 	}
-	lock{{$obj.InterfaceName}}Mock{{.Name}}.Lock()
+	mock.lock{{$obj.InterfaceName}}Mock{{.Name}}.Lock()
 	mock.calls.{{.Name}} = append(mock.calls.{{.Name}}, callInfo)
-	lock{{$obj.InterfaceName}}Mock{{.Name}}.Unlock()
+	mock.lock{{$obj.InterfaceName}}Mock{{.Name}}.Unlock()
 {{- if .ReturnArglist }}
 	return mock.{{.Name}}Func({{.ArgCallList}})
 {{- else }}
@@ -98,9 +92,9 @@ func (mock *{{$obj.InterfaceName}}Mock) {{.Name}}Calls() []struct {
 		{{ .Name | Exported }} {{ .Type }}
 		{{- end }}
 	}
-	lock{{$obj.InterfaceName}}Mock{{.Name}}.RLock()
+	mock.lock{{$obj.InterfaceName}}Mock{{.Name}}.RLock()
 	calls = mock.calls.{{.Name}}
-	lock{{$obj.InterfaceName}}Mock{{.Name}}.RUnlock()
+	mock.lock{{$obj.InterfaceName}}Mock{{.Name}}.RUnlock()
 	return calls
 }
 {{ end -}}

--- a/pkg/moq/testpackages/dotimport/service_moq_test.go
+++ b/pkg/moq/testpackages/dotimport/service_moq_test.go
@@ -4,17 +4,10 @@
 package dotimport_test
 
 import (
-	"github.com/matryer/moq/pkg/moq/testpackages/dotimport"
 	"sync"
-)
 
-var (
-	lockServiceMockUser sync.RWMutex
+	"github.com/matryer/moq/pkg/moq/testpackages/dotimport"
 )
-
-// Ensure, that ServiceMock does implement Service.
-// If this is not the case, regenerate this file with moq.
-var _ dotimport.Service = &ServiceMock{}
 
 // ServiceMock is a mock implementation of Service.
 //
@@ -43,6 +36,7 @@ type ServiceMock struct {
 			ID string
 		}
 	}
+	lockServiceMockUser sync.RWMutex
 }
 
 // User calls UserFunc.
@@ -55,9 +49,9 @@ func (mock *ServiceMock) User(ID string) (dotimport.User, error) {
 	}{
 		ID: ID,
 	}
-	lockServiceMockUser.Lock()
+	mock.lockServiceMockUser.Lock()
 	mock.calls.User = append(mock.calls.User, callInfo)
-	lockServiceMockUser.Unlock()
+	mock.lockServiceMockUser.Unlock()
 	return mock.UserFunc(ID)
 }
 
@@ -70,8 +64,8 @@ func (mock *ServiceMock) UserCalls() []struct {
 	var calls []struct {
 		ID string
 	}
-	lockServiceMockUser.RLock()
+	mock.lockServiceMockUser.RLock()
 	calls = mock.calls.User
-	lockServiceMockUser.RUnlock()
+	mock.lockServiceMockUser.RUnlock()
 	return calls
 }

--- a/pkg/moq/testpackages/gogenvendoring/user/user_moq_test.go
+++ b/pkg/moq/testpackages/gogenvendoring/user/user_moq_test.go
@@ -4,17 +4,10 @@
 package user
 
 import (
-	"github.com/matryer/somerepo"
 	"sync"
-)
 
-var (
-	lockServiceMockDoSomething sync.RWMutex
+	"github.com/matryer/somerepo"
 )
-
-// Ensure, that ServiceMock does implement Service.
-// If this is not the case, regenerate this file with moq.
-var _ Service = &ServiceMock{}
 
 // ServiceMock is a mock implementation of Service.
 //
@@ -43,6 +36,7 @@ type ServiceMock struct {
 			In1 somerepo.SomeType
 		}
 	}
+	lockServiceMockDoSomething sync.RWMutex
 }
 
 // DoSomething calls DoSomethingFunc.
@@ -55,9 +49,9 @@ func (mock *ServiceMock) DoSomething(in1 somerepo.SomeType) error {
 	}{
 		In1: in1,
 	}
-	lockServiceMockDoSomething.Lock()
+	mock.lockServiceMockDoSomething.Lock()
 	mock.calls.DoSomething = append(mock.calls.DoSomething, callInfo)
-	lockServiceMockDoSomething.Unlock()
+	mock.lockServiceMockDoSomething.Unlock()
 	return mock.DoSomethingFunc(in1)
 }
 
@@ -70,8 +64,8 @@ func (mock *ServiceMock) DoSomethingCalls() []struct {
 	var calls []struct {
 		In1 somerepo.SomeType
 	}
-	lockServiceMockDoSomething.RLock()
+	mock.lockServiceMockDoSomething.RLock()
 	calls = mock.calls.DoSomething
-	lockServiceMockDoSomething.RUnlock()
+	mock.lockServiceMockDoSomething.RUnlock()
 	return calls
 }


### PR DESCRIPTION
There is no need to keep the global mutex, they can be inside the mocked struct.