### PR TITLE
Go modules support

### DIFF
--- a/pkg/moq/moq.go
+++ b/pkg/moq/moq.go
@@ -239,18 +239,18 @@ func pkgInfoFromPath(src string) (*packages.Package, error) {
 		Dir:  src,
 	}
 
-	foundPackages, err := packages.Load(&conf, pkgFull)
+	pkgs, err := packages.Load(&conf, pkgFull)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(foundPackages) == 0 {
+	if len(pkgs) == 0 {
 		return nil, errors.New("No packages found")
 	}
-	if len(foundPackages) > 1 {
+	if len(pkgs) > 1 {
 		return nil, errors.New("More than one package was found")
 	}
-	return foundPackages[0], nil
+	return pkgs[0], nil
 }
 
 type doc struct {


### PR DESCRIPTION
Same as #76. Fixes #84
`go/packages` understands how to locate packages in a module-aware manner.

I've started to use go mod and got a lot of errors like this:
```
<project path outside GOPATH>/vendor/github.com/spf13/viper/viper.go:42:7: could not import github.com/pelletier/go-toml (go/build: importGo github.com/pelletier/go-toml: exit status 1
can't load package: package github.com/pelletier/go-toml: cannot find package "." in:
        <project path outside GOPATH>/vendor/github.com/spf13/viper/vendor/github.com/pelletier/go-toml
```