### PR TITLE
 Add aliases to imports

### DIFF
--- a/pkg/moq/moq_test.go
+++ b/pkg/moq/moq_test.go
@@ -217,8 +217,10 @@ func TestImports(t *testing.T) {
 	}
 	s := buf.String()
 	var strs = []string{
-		`	"sync"`,
-		`	"github.com/matryer/moq/pkg/moq/testpackages/imports/one"`,
+		`	sync "sync"`,
+		`	one "github.com/matryer/moq/pkg/moq/testpackages/imports/one"`,
+		`	http "github.com/matryer/moq/pkg/moq/testpackages/imports/http"`,
+		`	httpa "net/http"`,
 	}
 	for _, str := range strs {
 		if !strings.Contains(s, str) {

--- a/pkg/moq/template.go
+++ b/pkg/moq/template.go
@@ -12,7 +12,7 @@ package {{.PackageName}}
 
 import (
 {{- range .Imports }}
-	"{{.}}"
+	{{.}}
 {{- end }}
 )
 

--- a/pkg/moq/testpackages/imports/http/http.go
+++ b/pkg/moq/testpackages/imports/http/http.go
@@ -1,0 +1,4 @@
+package http
+
+// FancyStruct is fancy
+type FancyStruct struct{}

--- a/pkg/moq/testpackages/imports/two/two.go
+++ b/pkg/moq/testpackages/imports/two/two.go
@@ -1,6 +1,9 @@
 package two
 
 import (
+	"net/http"
+
+	myhttp "github.com/matryer/moq/pkg/moq/testpackages/imports/http"
 	"github.com/matryer/moq/pkg/moq/testpackages/imports/one"
 )
 
@@ -8,4 +11,5 @@ import (
 type DoSomething interface {
 	Do(thing one.Thing) error
 	Another(thing one.Thing) error
+	Duplicate(fancy myhttp.FancyStruct, lessFancy http.Request)
 }


### PR DESCRIPTION
Problem:
Two packages of the same name cant be imported

Solution:
Alias all imports to stop import conflicts

Fixes https://github.com/matryer/moq/issues/94