### PR TITLE
Declare working dependency version with go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/matryer/moq
+
+go 1.12
+
+require golang.org/x/tools v0.0.0-20190516213038-b9584148efcb

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190516213038-b9584148efcb h1:681euzctro3Bh/9df1r5G7RJNyezkvd/ZCC5rI0+1p8=
+golang.org/x/tools v0.0.0-20190516213038-b9584148efcb/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=


### PR DESCRIPTION
Some sort of incompatibility was introduced between `moq` and whatever version of `golang.org/x/tools/go/packages` I happened to have in my `$GOPATH` that resulted in `moq` failing with odd errors (see #98).

I was able to fix this by updating my copy of the dependency to the current version, though it took a bit for me to think to do that. Adding a `go.mod` file will ensure that builds of `mod` are done against a working version of `golang.org/x/tools/go/packages`, especially in Go 1.13+ which will have modules on by default.

Resolves #98.