### PR TITLE
Allow aliasing interface name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ moq [flags] destination interface [interface2 [interface3 [...]]]
     	output file (default stdout)
   -pkg string
     	package name (default will infer)
+Specifying an alias for the mock is also supported with the format 'interface:alias'
+Ex: moq -pkg different . MyInterface:MyMock
 ```
 
 In a command line:
@@ -63,7 +65,7 @@ In this example, Moq generated the `EmailSenderMock` type:
 ```go
 func TestCompleteSignup(t *testing.T) {
 
-	var sentTo string 
+	var sentTo string
 
 	mockedEmailSender = &EmailSenderMock{
 		SendFunc: func(to, subject, body string) error {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,8 @@ func main() {
 	flag.Usage = func() {
 		fmt.Println(`moq [flags] destination interface [interface2 [interface3 [...]]]`)
 		flag.PrintDefaults()
+		fmt.Println(`Specifying an alias for the mock is also supported with the format 'interface:alias'`)
+		fmt.Println(`Ex: moq -pkg different . MyInterface:MyMock`)
 	}
 	flag.Parse()
 	args := flag.Args()

--- a/pkg/moq/template.go
+++ b/pkg/moq/template.go
@@ -19,30 +19,30 @@ import (
 {{ range $i, $obj := .Objects -}}
 var (
 {{- range .Methods }}
-	lock{{$obj.InterfaceName}}Mock{{.Name}}	sync.RWMutex
+	lock{{$obj.MockName}}{{.Name}}	sync.RWMutex
 {{- end }}
 )
 
-// Ensure, that {{.InterfaceName}}Mock does implement {{.InterfaceName}}.
+// Ensure, that {{.MockName}} does implement {{.InterfaceName}}.
 // If this is not the case, regenerate this file with moq.
-var _ {{$sourcePackagePrefix}}{{.InterfaceName}} = &{{.InterfaceName}}Mock{}
+var _ {{$sourcePackagePrefix}}{{.InterfaceName}} = &{{.MockName}}{}
 
-// {{.InterfaceName}}Mock is a mock implementation of {{.InterfaceName}}.
+// {{.MockName}} is a mock implementation of {{$sourcePackagePrefix}}{{.InterfaceName}}.
 //
 //     func TestSomethingThatUses{{.InterfaceName}}(t *testing.T) {
 //
-//         // make and configure a mocked {{.InterfaceName}}
-//         mocked{{.InterfaceName}} := &{{.InterfaceName}}Mock{ {{ range .Methods }}
+//         // make and configure a mocked {{$sourcePackagePrefix}}{{.InterfaceName}}
+//         mocked{{.InterfaceName}} := &{{.MockName}}{ {{ range .Methods }}
 //             {{.Name}}Func: func({{ .Arglist }}) {{.ReturnArglist}} {
 // 	               panic("mock out the {{.Name}} method")
 //             },{{- end }}
 //         }
 //
-//         // use mocked{{.InterfaceName}} in code that requires {{.InterfaceName}}
+//         // use mocked{{.InterfaceName}} in code that requires {{$sourcePackagePrefix}}{{.InterfaceName}}
 //         // and then make assertions.
 //
 //     }
-type {{.InterfaceName}}Mock struct {
+type {{.MockName}} struct {
 {{- range .Methods }}
 	// {{.Name}}Func mocks the {{.Name}} method.
 	{{.Name}}Func func({{ .Arglist }}) {{.ReturnArglist}}
@@ -62,9 +62,9 @@ type {{.InterfaceName}}Mock struct {
 }
 {{ range .Methods }}
 // {{.Name}} calls {{.Name}}Func.
-func (mock *{{$obj.InterfaceName}}Mock) {{.Name}}({{.Arglist}}) {{.ReturnArglist}} {
+func (mock *{{$obj.MockName}}) {{.Name}}({{.Arglist}}) {{.ReturnArglist}} {
 	if mock.{{.Name}}Func == nil {
-		panic("{{$obj.InterfaceName}}Mock.{{.Name}}Func: method is nil but {{$obj.InterfaceName}}.{{.Name}} was just called")
+		panic("{{$obj.MockName}}.{{.Name}}Func: method is nil but {{$obj.InterfaceName}}.{{.Name}} was just called")
 	}
 	callInfo := struct {
 		{{- range .Params }}
@@ -75,9 +75,9 @@ func (mock *{{$obj.InterfaceName}}Mock) {{.Name}}({{.Arglist}}) {{.ReturnArglist
 		{{ .Name | Exported }}: {{ .Name }},
 		{{- end }}
 	}
-	lock{{$obj.InterfaceName}}Mock{{.Name}}.Lock()
+	lock{{$obj.MockName}}{{.Name}}.Lock()
 	mock.calls.{{.Name}} = append(mock.calls.{{.Name}}, callInfo)
-	lock{{$obj.InterfaceName}}Mock{{.Name}}.Unlock()
+	lock{{$obj.MockName}}{{.Name}}.Unlock()
 {{- if .ReturnArglist }}
 	return mock.{{.Name}}Func({{.ArgCallList}})
 {{- else }}
@@ -88,7 +88,7 @@ func (mock *{{$obj.InterfaceName}}Mock) {{.Name}}({{.Arglist}}) {{.ReturnArglist
 // {{.Name}}Calls gets all the calls that were made to {{.Name}}.
 // Check the length with:
 //     len(mocked{{$obj.InterfaceName}}.{{.Name}}Calls())
-func (mock *{{$obj.InterfaceName}}Mock) {{.Name}}Calls() []struct {
+func (mock *{{$obj.MockName}}) {{.Name}}Calls() []struct {
 		{{- range .Params }}
 		{{ .Name | Exported }} {{ .Type }}
 		{{- end }}
@@ -98,9 +98,9 @@ func (mock *{{$obj.InterfaceName}}Mock) {{.Name}}Calls() []struct {
 		{{ .Name | Exported }} {{ .Type }}
 		{{- end }}
 	}
-	lock{{$obj.InterfaceName}}Mock{{.Name}}.RLock()
+	lock{{$obj.MockName}}{{.Name}}.RLock()
 	calls = mock.calls.{{.Name}}
-	lock{{$obj.InterfaceName}}Mock{{.Name}}.RUnlock()
+	lock{{$obj.MockName}}{{.Name}}.RUnlock()
 	return calls
 }
 {{ end -}}


### PR DESCRIPTION
Implementation based on #57.
~~Additionally, handle the destination pkg having 'mock' in its name.~~ - not necessary, the user can define the alias as per their requirement.

TODO: Update README(need some tips)

Closes #57 
Closes #106 
Closes #67