### PR TITLE
Improve comment on type guard in template

### DIFF
--- a/pkg/moq/template.go
+++ b/pkg/moq/template.go
@@ -23,7 +23,7 @@ var (
 {{- end }}
 )
 
-// Ensure, that {{.MockName}} does implement {{.InterfaceName}}.
+// Ensure, that {{.MockName}} does implement {{$sourcePackagePrefix}}{{.InterfaceName}}.
 // If this is not the case, regenerate this file with moq.
 var _ {{$sourcePackagePrefix}}{{.InterfaceName}} = &{{.MockName}}{}
 


### PR DESCRIPTION
If the user specifies a different package and the mock name is the same
as the interface name, the type guard comment will be of the following
format:
```
Ensure, that MyInterface does implement MyInterface.
```
So use the `$sourcePackagePrefix` in the comment.