### PR TITLE
Run travis CI only on master branch and PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: go
 
 sudo: false
 
+branches:
+  only:
+    - master
+
 go:
   - 1.11.x
   - 1.12.x


### PR DESCRIPTION
If a PR is created using a branch pushed to origin, this triggers travis
CI twice(see #113), once for the PR and another for the branch. So run Travis CI for
only the `master` branch and when PRs are created using origin branches.
If CI needs to be run on any specific branch other than `master`, it would
need to be whitelisted.