### PR TITLE
Avoid deprecated LoadMode packages.{LoadFiles, LoadSyntax}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _testmain.go
 *.test
 *.prof
 .vscode
+.idea

--- a/pkg/moq/moq.go
+++ b/pkg/moq/moq.go
@@ -71,7 +71,7 @@ type Mocker struct {
 
 // New makes a new Mocker for the specified package directory.
 func New(src, packageName string) (*Mocker, error) {
-	srcPkg, err := pkgInfoFromPath(src, packages.LoadSyntax)
+	srcPkg, err := pkgInfoFromPath(src, packages.NeedName|packages.NeedTypes|packages.NeedTypesInfo)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't load source package: %s", err)
 	}
@@ -118,7 +118,7 @@ func findPkgPath(pkgInputVal string, srcPkg *packages.Package) (string, error) {
 }
 
 func pkgInDir(pkgName, dir string) bool {
-	currentPkg, err := pkgInfoFromPath(dir, packages.LoadFiles)
+	currentPkg, err := pkgInfoFromPath(dir, packages.NeedName)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
From the docs for `packages.{LoadFiles, LoadSyntax}` -
https://godoc.org/golang.org/x/tools/go/packages#pkg-constants

	// Deprecated: LoadFiles exists for historical compatibility
	// and should not be used. Please directly specify the needed
	// fields using the Need values.
	// ...
	// Deprecated: LoadSyntax exists for historical compatibility
	// and should not be used. Please directly specify the needed
	// fields using the Need values.