### PR TITLE
Handle package name collisions

### DIFF
--- a/pkg/moq/moq_test.go
+++ b/pkg/moq/moq_test.go
@@ -270,7 +270,34 @@ func TestImports(t *testing.T) {
 	s := buf.String()
 	var strs = []string{
 		`	"sync"`,
+		`	another "github.com/matryer/moq/pkg/moq/testpackages/imports/another/one"`,
 		`	"github.com/matryer/moq/pkg/moq/testpackages/imports/one"`,
+	}
+	for _, str := range strs {
+		if !strings.Contains(s, str) {
+			t.Errorf("expected but missing: \"%s\"", str)
+		}
+		if len(strings.Split(s, str)) > 2 {
+			t.Errorf("more than one: \"%s\"", str)
+		}
+	}
+}
+
+func TestImportsConflict(t *testing.T) {
+	m, err := New("testpackages/imports/three", "")
+	if err != nil {
+		t.Fatalf("moq.New: %s", err)
+	}
+	var buf bytes.Buffer
+	err = m.Mock(&buf, "DoFirst", "DoAnother")
+	if err != nil {
+		t.Errorf("m.Mock: %s", err)
+	}
+	s := buf.String()
+	var strs = []string{
+		`	"sync"`,
+		`	"github.com/matryer/moq/pkg/moq/testpackages/imports/one"`,
+		`	one1 "github.com/matryer/moq/pkg/moq/testpackages/imports/another/one"`,
 	}
 	for _, str := range strs {
 		if !strings.Contains(s, str) {
@@ -333,7 +360,7 @@ func TestVendoredInterface(t *testing.T) {
 	}
 	incorrectImport := `"github.com/matryer/moq/pkg/moq/testpackages/vendoring/vendor/github.com/matryer/somerepo"`
 	if strings.Contains(s, incorrectImport) {
-		t.Errorf("unexpected import: %s", incorrectImport)
+		t.Errorf("unexpected import: %s\n%s", incorrectImport, s)
 	}
 }
 

--- a/pkg/moq/template.go
+++ b/pkg/moq/template.go
@@ -12,7 +12,7 @@ package {{.PackageName}}
 
 import (
 {{- range .Imports }}
-	"{{.}}"
+	{{.}}
 {{- end }}
 )
 

--- a/pkg/moq/testpackages/imports/another/one/one.go
+++ b/pkg/moq/testpackages/imports/another/one/one.go
@@ -1,0 +1,4 @@
+package one
+
+// Thing is just a thing.
+type Thing struct{}

--- a/pkg/moq/testpackages/imports/three/another.go
+++ b/pkg/moq/testpackages/imports/three/another.go
@@ -1,0 +1,10 @@
+package two
+
+import (
+	"github.com/matryer/moq/pkg/moq/testpackages/imports/another/one"
+)
+
+// DoAnother does the other thing.
+type DoAnother interface {
+	Do(thing one.Thing) error
+}

--- a/pkg/moq/testpackages/imports/three/first.go
+++ b/pkg/moq/testpackages/imports/three/first.go
@@ -1,0 +1,10 @@
+package two
+
+import (
+	"github.com/matryer/moq/pkg/moq/testpackages/imports/one"
+)
+
+// DoFirst does the first thing.
+type DoFirst interface {
+	Do(thing one.Thing) error
+}

--- a/pkg/moq/testpackages/imports/two/two.go
+++ b/pkg/moq/testpackages/imports/two/two.go
@@ -1,11 +1,12 @@
 package two
 
 import (
+	another "github.com/matryer/moq/pkg/moq/testpackages/imports/another/one"
 	"github.com/matryer/moq/pkg/moq/testpackages/imports/one"
 )
 
 // DoSomething does something.
 type DoSomething interface {
 	Do(thing one.Thing) error
-	Another(thing one.Thing) error
+	Another(thing another.Thing) error
 }


### PR DESCRIPTION
Updates imports to add aliases (autogenerated using a numeral suffix) for package name collisions. This should address #68.