### PR TITLE
WIP: Support, carry over import aliases in interface src files

### DIFF
--- a/pkg/moq/moq_test.go
+++ b/pkg/moq/moq_test.go
@@ -449,3 +449,29 @@ func TestImportedPackageWithSameName(t *testing.T) {
 		t.Error("missing samename.A to address the struct A from the external package samename")
 	}
 }
+
+func TestImportAliases(t *testing.T) {
+	m, err := New("testpackages/importalias", "")
+	if err != nil {
+		t.Fatalf("moq.New: %s", err)
+	}
+
+	var buf bytes.Buffer
+	if err = m.Mock(&buf, "SalesService"); err != nil {
+		t.Errorf("mock error: %s", err)
+	}
+
+	s := buf.String()
+	// assertions of things that should be mentioned
+	var strs = []string{
+		`doucheclient "github.com/matryer/moq/pkg/moq/testpackages/importalias/douche/client"`,
+		`niceclient "github.com/matryer/moq/pkg/moq/testpackages/importalias/nice/client"`,
+		`	PitchEasyFunc func(p niceclient.Person)`,
+		`	PitchHardFunc func(p doucheclient.Person)`,
+	}
+	for _, str := range strs {
+		if !strings.Contains(s, str) {
+			t.Errorf("expected but missing: \"%s\"", str)
+		}
+	}
+}

--- a/pkg/moq/template.go
+++ b/pkg/moq/template.go
@@ -12,7 +12,7 @@ package {{.PackageName}}
 
 import (
 {{- range .Imports }}
-	"{{.}}"
+	{{.}}
 {{- end }}
 )
 

--- a/pkg/moq/testpackages/importalias/douche/client/douche_client.go
+++ b/pkg/moq/testpackages/importalias/douche/client/douche_client.go
@@ -1,0 +1,6 @@
+package client
+
+// Person is just a struct for testing
+type Person struct {
+	Name string
+}

--- a/pkg/moq/testpackages/importalias/nice/client/nice_client.go
+++ b/pkg/moq/testpackages/importalias/nice/client/nice_client.go
@@ -1,0 +1,6 @@
+package client
+
+// Person is just a struct for testing
+type Person struct {
+	Name string
+}

--- a/pkg/moq/testpackages/importalias/sales_service.go
+++ b/pkg/moq/testpackages/importalias/sales_service.go
@@ -1,0 +1,12 @@
+package importalias
+
+import (
+	doucheclient "github.com/matryer/moq/pkg/moq/testpackages/importalias/douche/client"
+	niceclient "github.com/matryer/moq/pkg/moq/testpackages/importalias/nice/client"
+)
+
+// SalesService is the interface which should be mocked by moq
+type SalesService interface {
+	PitchEasy(p niceclient.Person)
+	PitchHard(p doucheclient.Person)
+}


### PR DESCRIPTION
Import aliases used in the source files of target interface(s) are
carried over for the generated mock. Useful when the interface imports
multiple packages with the same name.

Closes #68 
Replaces and closes #120