### PR TITLE
Handle target interface inside vendor with other pkg name

### DIFF
--- a/pkg/moq/moq.go
+++ b/pkg/moq/moq.go
@@ -177,7 +177,7 @@ func (m *Mocker) Mock(w io.Writer, names ...string) error {
 
 	if tpkg.Name() != m.pkgName {
 		doc.SourcePackagePrefix = tpkg.Name() + "."
-		doc.Imports = append(doc.Imports, tpkg.Path())
+		doc.Imports = append(doc.Imports, stripVendorPath(tpkg.Path()))
 	}
 
 	var buf bytes.Buffer

--- a/pkg/moq/moq_test.go
+++ b/pkg/moq/moq_test.go
@@ -311,6 +311,32 @@ func TestVendoredPackages(t *testing.T) {
 	}
 }
 
+func TestVendoredInterface(t *testing.T) {
+	m, err := New("testpackages/vendoring/vendor/github.com/matryer/somerepo", "someother")
+	if err != nil {
+		t.Fatalf("moq.New: %s", err)
+	}
+	var buf bytes.Buffer
+	err = m.Mock(&buf, "SomeService")
+	if err != nil {
+		t.Errorf("mock error: %s", err)
+	}
+	s := buf.String()
+	// assertions of things that should be mentioned
+	var strs = []string{
+		`"github.com/matryer/somerepo"`,
+	}
+	for _, str := range strs {
+		if !strings.Contains(s, str) {
+			t.Errorf("expected but missing: \"%s\"", str)
+		}
+	}
+	incorrectImport := `"github.com/matryer/moq/pkg/moq/testpackages/vendoring/vendor/github.com/matryer/somerepo"`
+	if strings.Contains(s, incorrectImport) {
+		t.Errorf("unexpected import: %s", incorrectImport)
+	}
+}
+
 func TestVendoredBuildConstraints(t *testing.T) {
 	m, err := New("testpackages/buildconstraints/user", "")
 	if err != nil {

--- a/pkg/moq/testpackages/vendoring/vendor/github.com/matryer/somerepo/code.go
+++ b/pkg/moq/testpackages/vendoring/vendor/github.com/matryer/somerepo/code.go
@@ -7,3 +7,7 @@ type SomeType struct {
 	// Truth indicates whether true is true or not. Computers.
 	Truth bool
 }
+
+type SomeService interface {
+	Get() SomeType
+}


### PR DESCRIPTION
When the interface that we are trying to moq is present inside the vendor
directory and the output package name is different, the import needs to be
stripped of the vendor path.

Closes #18 (see https://github.com/matryer/moq/issues/18#issuecomment-463004812)