### PR TITLE
fix gosec vulnerabilities: file and directory permissions

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,10 +90,10 @@ func run(flags userFlags) error {
 	}
 
 	// create the file
-	err = os.MkdirAll(filepath.Dir(flags.outFile), 0755)
+	err = os.MkdirAll(filepath.Dir(flags.outFile), 0750)
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(flags.outFile, buf.Bytes(), 0644)
+	return ioutil.WriteFile(flags.outFile, buf.Bytes(), 0600)
 }

--- a/pkg/moq/moq_modules_test.go
+++ b/pkg/moq/moq_modules_test.go
@@ -15,7 +15,7 @@ import (
 // copy copies srcPath to destPath, dirs and files
 func copy(srcPath, destPath string, item os.FileInfo) error {
 	if item.IsDir() {
-		if err := os.MkdirAll(destPath, os.FileMode(0755)); err != nil {
+		if err := os.MkdirAll(destPath, os.FileMode(0750)); err != nil {
 			return err
 		}
 		items, err := ioutil.ReadDir(srcPath)

--- a/pkg/moq/moq_test.go
+++ b/pkg/moq/moq_test.go
@@ -385,10 +385,10 @@ func matchGoldenFile(goldenFile string, actual []byte) error {
 	// To update golden files, run the following:
 	// go test -v -run '^<Test-Name>$' github.com/matryer/moq/pkg/moq -update
 	if *update {
-		if err := os.MkdirAll(filepath.Dir(goldenFile), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(goldenFile), 0750); err != nil {
 			return fmt.Errorf("create dir: %s", err)
 		}
-		if err := ioutil.WriteFile(goldenFile, actual, 0644); err != nil {
+		if err := ioutil.WriteFile(goldenFile, actual, 0600); err != nil {
 			return fmt.Errorf("write: %s", err)
 		}
 


### PR DESCRIPTION
[Gosec](https://github.com/securego/gosec) found some vulnerabilities:
* Expect directory permissions to be 0750 or less
* Expect WriteFile permissions to be 0600 or less

based on https://cwe.mitre.org/data/definitions/276.html