### PR TITLE
Fix var name generation to avoid conflict

### DIFF
--- a/internal/registry/var.go
+++ b/internal/registry/var.go
@@ -38,7 +38,25 @@ func (v Var) packageQualifier(pkg *types.Package) string {
 	return v.imports[path].Qualifier()
 }
 
-// generateVarName generates a name for the variable using the type
+func varName(vr *types.Var, suffix string) string {
+	name := vr.Name()
+	if name != "" && name != "_" {
+		return name + suffix
+	}
+
+	name = varNameForType(vr.Type()) + suffix
+
+	switch name {
+	case "mock", "callInfo", "break", "default", "func", "interface", "select", "case", "defer", "go", "map", "struct",
+		"chan", "else", "goto", "package", "switch", "const", "fallthrough", "if", "range", "type", "continue", "for",
+		"import", "return", "var":
+		name += "MoqParam"
+	}
+
+	return name
+}
+
+// varNameForType generates a name for the variable using the type
 // information.
 //
 // Examples:
@@ -49,12 +67,12 @@ func (v Var) packageQualifier(pkg *types.Package) string {
 // - map[string]int -> stringToInt
 // - error -> err
 // - a.MyType -> myType
-func generateVarName(t types.Type) string {
+func varNameForType(t types.Type) string {
 	nestedType := func(t types.Type) string {
 		if t, ok := t.(*types.Basic); ok {
 			return deCapitalise(t.String())
 		}
-		return generateVarName(t)
+		return varNameForType(t)
 	}
 
 	switch t := t.(type) {
@@ -83,7 +101,7 @@ func generateVarName(t types.Type) string {
 		return "val"
 
 	case *types.Pointer:
-		return generateVarName(t.Elem())
+		return varNameForType(t.Elem())
 
 	case *types.Signature:
 		return "fn"

--- a/pkg/moq/testpackages/paramconflict/iface.go
+++ b/pkg/moq/testpackages/paramconflict/iface.go
@@ -1,5 +1,7 @@
 package paramconflict
 
+import "time"
+
 type Interface interface {
-	Method(string, bool, string, bool, int, int32, int64, float32, float64)
+	Method(string, bool, string, bool, int, int32, int64, float32, float64, time.Time, time.Time)
 }

--- a/pkg/moq/testpackages/paramconflict/iface_moq.golden.go
+++ b/pkg/moq/testpackages/paramconflict/iface_moq.golden.go
@@ -5,6 +5,7 @@ package paramconflict
 
 import (
 	"sync"
+	"time"
 )
 
 // Ensure, that InterfaceMock does implement Interface.
@@ -17,7 +18,7 @@ var _ Interface = &InterfaceMock{}
 //
 // 		// make and configure a mocked Interface
 // 		mockedInterface := &InterfaceMock{
-// 			MethodFunc: func(s1 string, b1 bool, s2 string, b2 bool, n1 int, n2 int32, n3 int64, f1 float32, f2 float64)  {
+// 			MethodFunc: func(s1 string, b1 bool, s2 string, b2 bool, n1 int, n2 int32, n3 int64, f1 float32, f2 float64, timeMoqParam1 time.Time, timeMoqParam2 time.Time)  {
 // 				panic("mock out the Method method")
 // 			},
 // 		}
@@ -28,7 +29,7 @@ var _ Interface = &InterfaceMock{}
 // 	}
 type InterfaceMock struct {
 	// MethodFunc mocks the Method method.
-	MethodFunc func(s1 string, b1 bool, s2 string, b2 bool, n1 int, n2 int32, n3 int64, f1 float32, f2 float64)
+	MethodFunc func(s1 string, b1 bool, s2 string, b2 bool, n1 int, n2 int32, n3 int64, f1 float32, f2 float64, timeMoqParam1 time.Time, timeMoqParam2 time.Time)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -52,67 +53,79 @@ type InterfaceMock struct {
 			F1 float32
 			// F2 is the f2 argument value.
 			F2 float64
+			// TimeMoqParam1 is the timeMoqParam1 argument value.
+			TimeMoqParam1 time.Time
+			// TimeMoqParam2 is the timeMoqParam2 argument value.
+			TimeMoqParam2 time.Time
 		}
 	}
 	lockMethod sync.RWMutex
 }
 
 // Method calls MethodFunc.
-func (mock *InterfaceMock) Method(s1 string, b1 bool, s2 string, b2 bool, n1 int, n2 int32, n3 int64, f1 float32, f2 float64) {
+func (mock *InterfaceMock) Method(s1 string, b1 bool, s2 string, b2 bool, n1 int, n2 int32, n3 int64, f1 float32, f2 float64, timeMoqParam1 time.Time, timeMoqParam2 time.Time) {
 	if mock.MethodFunc == nil {
 		panic("InterfaceMock.MethodFunc: method is nil but Interface.Method was just called")
 	}
 	callInfo := struct {
-		S1 string
-		B1 bool
-		S2 string
-		B2 bool
-		N1 int
-		N2 int32
-		N3 int64
-		F1 float32
-		F2 float64
+		S1            string
+		B1            bool
+		S2            string
+		B2            bool
+		N1            int
+		N2            int32
+		N3            int64
+		F1            float32
+		F2            float64
+		TimeMoqParam1 time.Time
+		TimeMoqParam2 time.Time
 	}{
-		S1: s1,
-		B1: b1,
-		S2: s2,
-		B2: b2,
-		N1: n1,
-		N2: n2,
-		N3: n3,
-		F1: f1,
-		F2: f2,
+		S1:            s1,
+		B1:            b1,
+		S2:            s2,
+		B2:            b2,
+		N1:            n1,
+		N2:            n2,
+		N3:            n3,
+		F1:            f1,
+		F2:            f2,
+		TimeMoqParam1: timeMoqParam1,
+		TimeMoqParam2: timeMoqParam2,
 	}
 	mock.lockMethod.Lock()
 	mock.calls.Method = append(mock.calls.Method, callInfo)
 	mock.lockMethod.Unlock()
-	mock.MethodFunc(s1, b1, s2, b2, n1, n2, n3, f1, f2)
+	mock.MethodFunc(s1, b1, s2, b2, n1, n2, n3, f1, f2, timeMoqParam1, timeMoqParam2)
 }
 
 // MethodCalls gets all the calls that were made to Method.
 // Check the length with:
 //     len(mockedInterface.MethodCalls())
 func (mock *InterfaceMock) MethodCalls() []struct {
-	S1 string
-	B1 bool
-	S2 string
-	B2 bool
-	N1 int
-	N2 int32
-	N3 int64
-	F1 float32
-	F2 float64
+	S1            string
+	B1            bool
+	S2            string
+	B2            bool
+	N1            int
+	N2            int32
+	N3            int64
+	F1            float32
+	F2            float64
+	TimeMoqParam1 time.Time
+	TimeMoqParam2 time.Time
 } {
 	var calls []struct {
-		S1 string
-		B1 bool
-		S2 string
-		B2 bool
-		N1 int
-		N2 int32
-		N3 int64
-		F1 float32
-		F2 float64
+		S1            string
+		B1            bool
+		S2            string
+		B2            bool
+		N1            int
+		N2            int32
+		N3            int64
+		F1            float32
+		F2            float64
+		TimeMoqParam1 time.Time
+		TimeMoqParam2 time.Time
 	}
 	mock.lockMethod.RLock()
 	calls = mock.calls.Method


### PR DESCRIPTION
When the type and the package name is the same for an anonymous
parameter (ex: time.Time), and there are more than 1 such parameters,
the generated name for both was the same. And the generated code would
not be valid.

Fix the bug by ensuring the parameter name does not conflict with
package imports first before checking against other parameter names.

Closes #144 

cc: @breml 