### PR TITLE
rm flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Interface mocking tool for go generate.
 
+### Fork
+
+This is a fork of https://github.com/matryer/moq, for use until https://github.com/matryer/moq/pull/149 is merged/resolved.
+
 ### What is Moq?
 
 Moq is a tool that generates a struct from any interface. The struct can be used in test code as a mock of the interface.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/matryer/moq
+module github.com/soniah/moq
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ type userFlags struct {
 	formatter  string
 	stubImpl   bool
 	skipEnsure bool
+	remove     bool
 	args       []string
 }
 
@@ -35,6 +36,7 @@ func main() {
 	printVersion := flag.Bool("version", false, "show the version for moq")
 	flag.BoolVar(&flags.skipEnsure, "skip-ensure", false,
 		"suppress mock implementation check, avoid import cycle if mocks generated outside of the tested package")
+	flag.BoolVar(&flags.remove, "rm", false, "first remove output file, if it exists")
 
 	flag.Usage = func() {
 		fmt.Println(`moq [flags] source-dir interface [interface2 [interface3 [...]]]`)
@@ -61,6 +63,14 @@ func main() {
 func run(flags userFlags) error {
 	if len(flags.args) < 2 {
 		return errors.New("not enough arguments")
+	}
+
+	if flags.remove && flags.outFile != "" {
+		if err := os.Remove(flags.outFile); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+		}
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
This PR adds a `-rm` flag, that allows for the target mock file to be removed (if it already exists).

Mock generation occasionally fails. But when the target mock file is removed and `moq` is run again, the generation succeeds.

This has happened for me and my colleagues, across multiple projects at multiple companies. Sorry I haven't got an examples at hand 😄 


