### PR TITLE
Add an optional Hydrate(Interface) method

### DIFF
--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -56,7 +56,7 @@ var _ {{$.SrcPkgQualifier}}{{.InterfaceName}} = &{{.MockName}}{}
 // 	func TestSomethingThatUses{{.InterfaceName}}(t *testing.T) {
 //
 // 		// make and configure a mocked {{$.SrcPkgQualifier}}{{.InterfaceName}}
-// 		mocked{{.InterfaceName}} := &{{.MockName}}{ 
+// 		mocked{{.InterfaceName}} := &{{.MockName}}{
 			{{- range .Methods}}
 // 			{{.Name}}Func: func({{.ArgList}}) {{.ReturnArgTypeList}} {
 // 				panic("mock out the {{.Name}} method")
@@ -148,6 +148,17 @@ func (mock *{{$mock.MockName}}) {{.Name}}Calls() []struct {
 	calls = mock.calls.{{.Name}}
 	mock.lock{{.Name}}.RUnlock()
 	return calls
+}
+{{end -}}
+
+{{- if $.IncludeHydrate}}
+// Hydrate replaces any non-mocked methods with the corresponding method from the given implementation.
+func (mock *{{$mock.MockName}}) Hydrate(i {{$mock.InterfaceName}}) {
+        {{range .Methods -}}
+        if mock.{{.Name}}Func == nil {
+                mock.{{.Name}}Func = i.{{.Name}}
+        }
+        {{end -}}
 }
 {{end -}}
 {{end -}}`

--- a/internal/template/template_data.go
+++ b/internal/template/template_data.go
@@ -14,6 +14,7 @@ type Data struct {
 	Imports         []*registry.Package
 	Mocks           []MockData
 	StubImpl        bool
+	IncludeHydrate  bool
 	SkipEnsure      bool
 }
 

--- a/main.go
+++ b/main.go
@@ -17,13 +17,14 @@ import (
 var Version string = "dev"
 
 type userFlags struct {
-	outFile    string
-	pkgName    string
-	formatter  string
-	stubImpl   bool
-	skipEnsure bool
-	remove     bool
-	args       []string
+	outFile        string
+	pkgName        string
+	formatter      string
+	stubImpl       bool
+	includeHydrate bool
+	skipEnsure     bool
+	remove         bool
+	args           []string
 }
 
 func main() {
@@ -33,6 +34,8 @@ func main() {
 	flag.StringVar(&flags.formatter, "fmt", "", "go pretty-printer: gofmt, goimports or noop (default gofmt)")
 	flag.BoolVar(&flags.stubImpl, "stub", false,
 		"return zero values when no mock implementation is provided, do not panic")
+	flag.BoolVar(&flags.includeHydrate, "hydrate", false,
+		"include Hydrate(Interface) which replaces non-mocked methods with methods from the given implementation")
 	printVersion := flag.Bool("version", false, "show the version for moq")
 	flag.BoolVar(&flags.skipEnsure, "skip-ensure", false,
 		"suppress mock implementation check, avoid import cycle if mocks generated outside of the tested package")
@@ -81,11 +84,12 @@ func run(flags userFlags) error {
 
 	srcDir, args := flags.args[0], flags.args[1:]
 	m, err := moq.New(moq.Config{
-		SrcDir:     srcDir,
-		PkgName:    flags.pkgName,
-		Formatter:  flags.formatter,
-		StubImpl:   flags.stubImpl,
-		SkipEnsure: flags.skipEnsure,
+		SrcDir:         srcDir,
+		PkgName:        flags.pkgName,
+		Formatter:      flags.formatter,
+		StubImpl:       flags.stubImpl,
+		IncludeHydrate: flags.includeHydrate,
+		SkipEnsure:     flags.skipEnsure,
 	})
 	if err != nil {
 		return err

--- a/pkg/moq/moq.go
+++ b/pkg/moq/moq.go
@@ -22,11 +22,12 @@ type Mocker struct {
 // Config specifies details about how interfaces should be mocked.
 // SrcDir is the only field which needs be specified.
 type Config struct {
-	SrcDir     string
-	PkgName    string
-	Formatter  string
-	StubImpl   bool
-	SkipEnsure bool
+	SrcDir         string
+	PkgName        string
+	Formatter      string
+	StubImpl       bool
+	IncludeHydrate bool
+	SkipEnsure     bool
 }
 
 // New makes a new Mocker for the specified package directory.
@@ -75,10 +76,11 @@ func (m *Mocker) Mock(w io.Writer, namePairs ...string) error {
 	}
 
 	data := template.Data{
-		PkgName:    m.mockPkgName(),
-		Mocks:      mocks,
-		StubImpl:   m.cfg.StubImpl,
-		SkipEnsure: m.cfg.SkipEnsure,
+		PkgName:        m.mockPkgName(),
+		Mocks:          mocks,
+		StubImpl:       m.cfg.StubImpl,
+		IncludeHydrate: m.cfg.IncludeHydrate,
+		SkipEnsure:     m.cfg.SkipEnsure,
 	}
 
 	if data.MocksSomeMethod() {


### PR DESCRIPTION
Fixes #161 The changeset was ultimately very small so I've just gone ahead and opened a PR pending discussion.

Adds the `--hydrate` option which if invoked produces an additional method on the mock `Hydrate(t Interface)` which replaces any nil mock funcs with the corresponding method from the given implementation. 