### PR TITLE
Update .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
   - arm
   - arm64
   ldflags:
-  - -X main.Version={{.Version}}
+  - -X main.version={{.Version}}
 archives:
 - replacements:
     darwin: macOS


### PR DESCRIPTION
Fixes `moq -version` returning `moq version dev`