### PR TITLE
Test on Go 1.{18, 19}

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,19 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
+      - run: git fetch --force --tags
+
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
+          cache: true
+          check-latest: true
 
       -
         name: Run GoReleaser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,45 +13,37 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest,macos-latest,windows-latest]
-        go-version: [1.14.x, 1.15.x, 1.17.x, 1.18.x]
-        # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-new-combinations
-        exclude:
+        os: [ubuntu-latest]
+        go-version: [1.18.x, 1.19.x]
+        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-expanding-configurations
+        include:
           - os: windows-latest
-            go-version: 1.14.x
+            go-version: 1.19.x
           - os: macos-latest
-            go-version: 1.14.x
+            go-version: 1.19.x
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      # See https://github.com/actions/cache/blob/master/examples.md#go---modules
-      - name: Cache Go Modules
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
 
       - name: Go install moq
-        run: go install -mod=readonly
+        run: go install
 
       - name: Run vet
         if: matrix.os == 'ubuntu-latest'
-        run: go vet -mod=readonly ./...
+        run: go vet ./...
 
       - name: Lint
         if: matrix.os == 'ubuntu-latest'
         run: |
-          GO111MODULE=off go get -u golang.org/x/lint/golint
+          go install golang.org/x/lint/golint@latest
           golint ./...
 
       - name: Test
-        run: go test -mod=readonly ./...
+        run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,10 @@ go 1.18
 
 require (
 	github.com/pmezard/go-difflib v1.0.0
-	golang.org/x/tools v0.1.10
+	golang.org/x/tools v0.3.0
 )
 
 require (
-	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
-	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	golang.org/x/mod v0.7.0 // indirect
+	golang.org/x/sys v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,9 @@
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 h1:kQgndtyPBW/JIYERgdxfwMYh3AVStj88WQTlNDi2a+o=
-golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
-golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
+golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.3.0 h1:SrNbZl6ECOS1qFzgTdQfWXZM9XBkiA6tkFrH9YSTPHM=
+golang.org/x/tools v0.3.0/go.mod h1:/rWhSS2+zyEVwoJf8YAX6L2f0ntZ7Kn/mGgAWcipA5k=

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -68,21 +68,21 @@ var _ {{$.SrcPkgQualifier}}{{.InterfaceName -}}
 
 // {{.MockName}} is a mock implementation of {{$.SrcPkgQualifier}}{{.InterfaceName}}.
 //
-// 	func TestSomethingThatUses{{.InterfaceName}}(t *testing.T) {
+//	func TestSomethingThatUses{{.InterfaceName}}(t *testing.T) {
 //
-// 		// make and configure a mocked {{$.SrcPkgQualifier}}{{.InterfaceName}}
-// 		mocked{{.InterfaceName}} := &{{.MockName}}{ 
+//		// make and configure a mocked {{$.SrcPkgQualifier}}{{.InterfaceName}}
+//		mocked{{.InterfaceName}} := &{{.MockName}}{
 			{{- range .Methods}}
-// 			{{.Name}}Func: func({{.ArgList}}) {{.ReturnArgTypeList}} {
-// 				panic("mock out the {{.Name}} method")
-// 			},
+//			{{.Name}}Func: func({{.ArgList}}) {{.ReturnArgTypeList}} {
+//				panic("mock out the {{.Name}} method")
+//			},
 			{{- end}}
-// 		}
+//		}
 //
-// 		// use mocked{{.InterfaceName}} in code that requires {{$.SrcPkgQualifier}}{{.InterfaceName}}
-// 		// and then make assertions.
+//		// use mocked{{.InterfaceName}} in code that requires {{$.SrcPkgQualifier}}{{.InterfaceName}}
+//		// and then make assertions.
 //
-// 	}
+//	}
 type {{.MockName}} 
 {{- if .TypeParams -}}
 	[{{- range $index, $param := .TypeParams}}
@@ -159,7 +159,8 @@ func (mock *{{$mock.MockName}}
 
 // {{.Name}}Calls gets all the calls that were made to {{.Name}}.
 // Check the length with:
-//     len(mocked{{$mock.InterfaceName}}.{{.Name}}Calls())
+//
+//	len(mocked{{$mock.InterfaceName}}.{{.Name}}Calls())
 func (mock *{{$mock.MockName}}
 {{- if $mock.TypeParams -}}
 	[{{- range $index, $param := $mock.TypeParams}}

--- a/pkg/moq/testpackages/anonimport/iface_moq.golden.go
+++ b/pkg/moq/testpackages/anonimport/iface_moq.golden.go
@@ -14,19 +14,19 @@ var _ Example = &ExampleMock{}
 
 // ExampleMock is a mock implementation of Example.
 //
-// 	func TestSomethingThatUsesExample(t *testing.T) {
+//	func TestSomethingThatUsesExample(t *testing.T) {
 //
-// 		// make and configure a mocked Example
-// 		mockedExample := &ExampleMock{
-// 			CtxFunc: func(ctx context.Context)  {
-// 				panic("mock out the Ctx method")
-// 			},
-// 		}
+//		// make and configure a mocked Example
+//		mockedExample := &ExampleMock{
+//			CtxFunc: func(ctx context.Context)  {
+//				panic("mock out the Ctx method")
+//			},
+//		}
 //
-// 		// use mockedExample in code that requires Example
-// 		// and then make assertions.
+//		// use mockedExample in code that requires Example
+//		// and then make assertions.
 //
-// 	}
+//	}
 type ExampleMock struct {
 	// CtxFunc mocks the Ctx method.
 	CtxFunc func(ctx context.Context)
@@ -60,7 +60,8 @@ func (mock *ExampleMock) Ctx(ctx context.Context) {
 
 // CtxCalls gets all the calls that were made to Ctx.
 // Check the length with:
-//     len(mockedExample.CtxCalls())
+//
+//	len(mockedExample.CtxCalls())
 func (mock *ExampleMock) CtxCalls() []struct {
 	Ctx context.Context
 } {

--- a/pkg/moq/testpackages/blankid/swallower.golden.go
+++ b/pkg/moq/testpackages/blankid/swallower.golden.go
@@ -13,19 +13,19 @@ var _ Swallower = &SwallowerMock{}
 
 // SwallowerMock is a mock implementation of Swallower.
 //
-// 	func TestSomethingThatUsesSwallower(t *testing.T) {
+//	func TestSomethingThatUsesSwallower(t *testing.T) {
 //
-// 		// make and configure a mocked Swallower
-// 		mockedSwallower := &SwallowerMock{
-// 			SwallowFunc: func(s string)  {
-// 				panic("mock out the Swallow method")
-// 			},
-// 		}
+//		// make and configure a mocked Swallower
+//		mockedSwallower := &SwallowerMock{
+//			SwallowFunc: func(s string)  {
+//				panic("mock out the Swallow method")
+//			},
+//		}
 //
-// 		// use mockedSwallower in code that requires Swallower
-// 		// and then make assertions.
+//		// use mockedSwallower in code that requires Swallower
+//		// and then make assertions.
 //
-// 	}
+//	}
 type SwallowerMock struct {
 	// SwallowFunc mocks the Swallow method.
 	SwallowFunc func(s string)
@@ -59,7 +59,8 @@ func (mock *SwallowerMock) Swallow(s string) {
 
 // SwallowCalls gets all the calls that were made to Swallow.
 // Check the length with:
-//     len(mockedSwallower.SwallowCalls())
+//
+//	len(mockedSwallower.SwallowCalls())
 func (mock *SwallowerMock) SwallowCalls() []struct {
 	S string
 } {

--- a/pkg/moq/testpackages/channels/queuer_moq.golden.go
+++ b/pkg/moq/testpackages/channels/queuer_moq.golden.go
@@ -13,22 +13,22 @@ var _ Queuer = &QueuerMock{}
 
 // QueuerMock is a mock implementation of Queuer.
 //
-// 	func TestSomethingThatUsesQueuer(t *testing.T) {
+//	func TestSomethingThatUsesQueuer(t *testing.T) {
 //
-// 		// make and configure a mocked Queuer
-// 		mockedQueuer := &QueuerMock{
-// 			SubFunc: func(topic string) (<-chan Queue, error) {
-// 				panic("mock out the Sub method")
-// 			},
-// 			UnsubFunc: func(topic string)  {
-// 				panic("mock out the Unsub method")
-// 			},
-// 		}
+//		// make and configure a mocked Queuer
+//		mockedQueuer := &QueuerMock{
+//			SubFunc: func(topic string) (<-chan Queue, error) {
+//				panic("mock out the Sub method")
+//			},
+//			UnsubFunc: func(topic string)  {
+//				panic("mock out the Unsub method")
+//			},
+//		}
 //
-// 		// use mockedQueuer in code that requires Queuer
-// 		// and then make assertions.
+//		// use mockedQueuer in code that requires Queuer
+//		// and then make assertions.
 //
-// 	}
+//	}
 type QueuerMock struct {
 	// SubFunc mocks the Sub method.
 	SubFunc func(topic string) (<-chan Queue, error)
@@ -75,7 +75,8 @@ func (mock *QueuerMock) Sub(topic string) (<-chan Queue, error) {
 
 // SubCalls gets all the calls that were made to Sub.
 // Check the length with:
-//     len(mockedQueuer.SubCalls())
+//
+//	len(mockedQueuer.SubCalls())
 func (mock *QueuerMock) SubCalls() []struct {
 	Topic string
 } {
@@ -106,7 +107,8 @@ func (mock *QueuerMock) Unsub(topic string) {
 
 // UnsubCalls gets all the calls that were made to Unsub.
 // Check the length with:
-//     len(mockedQueuer.UnsubCalls())
+//
+//	len(mockedQueuer.UnsubCalls())
 func (mock *QueuerMock) UnsubCalls() []struct {
 	Topic string
 } {

--- a/pkg/moq/testpackages/generics/generics_moq.golden.go
+++ b/pkg/moq/testpackages/generics/generics_moq.golden.go
@@ -14,22 +14,22 @@ var _ GenericStore1[Key1, any] = &GenericStore1Mock[Key1, any]{}
 
 // GenericStore1Mock is a mock implementation of GenericStore1.
 //
-// 	func TestSomethingThatUsesGenericStore1(t *testing.T) {
+//	func TestSomethingThatUsesGenericStore1(t *testing.T) {
 //
-// 		// make and configure a mocked GenericStore1
-// 		mockedGenericStore1 := &GenericStore1Mock{
-// 			CreateFunc: func(ctx context.Context, id T, value S) error {
-// 				panic("mock out the Create method")
-// 			},
-// 			GetFunc: func(ctx context.Context, id T) (S, error) {
-// 				panic("mock out the Get method")
-// 			},
-// 		}
+//		// make and configure a mocked GenericStore1
+//		mockedGenericStore1 := &GenericStore1Mock{
+//			CreateFunc: func(ctx context.Context, id T, value S) error {
+//				panic("mock out the Create method")
+//			},
+//			GetFunc: func(ctx context.Context, id T) (S, error) {
+//				panic("mock out the Get method")
+//			},
+//		}
 //
-// 		// use mockedGenericStore1 in code that requires GenericStore1
-// 		// and then make assertions.
+//		// use mockedGenericStore1 in code that requires GenericStore1
+//		// and then make assertions.
 //
-// 	}
+//	}
 type GenericStore1Mock[T Key1, S any] struct {
 	// CreateFunc mocks the Create method.
 	CreateFunc func(ctx context.Context, id T, value S) error
@@ -82,7 +82,8 @@ func (mock *GenericStore1Mock[T, S]) Create(ctx context.Context, id T, value S) 
 
 // CreateCalls gets all the calls that were made to Create.
 // Check the length with:
-//     len(mockedGenericStore1.CreateCalls())
+//
+//	len(mockedGenericStore1.CreateCalls())
 func (mock *GenericStore1Mock[T, S]) CreateCalls() []struct {
 	Ctx   context.Context
 	ID    T
@@ -119,7 +120,8 @@ func (mock *GenericStore1Mock[T, S]) Get(ctx context.Context, id T) (S, error) {
 
 // GetCalls gets all the calls that were made to Get.
 // Check the length with:
-//     len(mockedGenericStore1.GetCalls())
+//
+//	len(mockedGenericStore1.GetCalls())
 func (mock *GenericStore1Mock[T, S]) GetCalls() []struct {
 	Ctx context.Context
 	ID  T
@@ -140,22 +142,22 @@ var _ GenericStore2[[]byte, any] = &GenericStore2Mock[[]byte, any]{}
 
 // GenericStore2Mock is a mock implementation of GenericStore2.
 //
-// 	func TestSomethingThatUsesGenericStore2(t *testing.T) {
+//	func TestSomethingThatUsesGenericStore2(t *testing.T) {
 //
-// 		// make and configure a mocked GenericStore2
-// 		mockedGenericStore2 := &GenericStore2Mock{
-// 			CreateFunc: func(ctx context.Context, id T, value S) error {
-// 				panic("mock out the Create method")
-// 			},
-// 			GetFunc: func(ctx context.Context, id T) (S, error) {
-// 				panic("mock out the Get method")
-// 			},
-// 		}
+//		// make and configure a mocked GenericStore2
+//		mockedGenericStore2 := &GenericStore2Mock{
+//			CreateFunc: func(ctx context.Context, id T, value S) error {
+//				panic("mock out the Create method")
+//			},
+//			GetFunc: func(ctx context.Context, id T) (S, error) {
+//				panic("mock out the Get method")
+//			},
+//		}
 //
-// 		// use mockedGenericStore2 in code that requires GenericStore2
-// 		// and then make assertions.
+//		// use mockedGenericStore2 in code that requires GenericStore2
+//		// and then make assertions.
 //
-// 	}
+//	}
 type GenericStore2Mock[T Key2, S any] struct {
 	// CreateFunc mocks the Create method.
 	CreateFunc func(ctx context.Context, id T, value S) error
@@ -208,7 +210,8 @@ func (mock *GenericStore2Mock[T, S]) Create(ctx context.Context, id T, value S) 
 
 // CreateCalls gets all the calls that were made to Create.
 // Check the length with:
-//     len(mockedGenericStore2.CreateCalls())
+//
+//	len(mockedGenericStore2.CreateCalls())
 func (mock *GenericStore2Mock[T, S]) CreateCalls() []struct {
 	Ctx   context.Context
 	ID    T
@@ -245,7 +248,8 @@ func (mock *GenericStore2Mock[T, S]) Get(ctx context.Context, id T) (S, error) {
 
 // GetCalls gets all the calls that were made to Get.
 // Check the length with:
-//     len(mockedGenericStore2.GetCalls())
+//
+//	len(mockedGenericStore2.GetCalls())
 func (mock *GenericStore2Mock[T, S]) GetCalls() []struct {
 	Ctx context.Context
 	ID  T
@@ -266,22 +270,22 @@ var _ AliasStore = &AliasStoreMock{}
 
 // AliasStoreMock is a mock implementation of AliasStore.
 //
-// 	func TestSomethingThatUsesAliasStore(t *testing.T) {
+//	func TestSomethingThatUsesAliasStore(t *testing.T) {
 //
-// 		// make and configure a mocked AliasStore
-// 		mockedAliasStore := &AliasStoreMock{
-// 			CreateFunc: func(ctx context.Context, id KeyImpl, value bool) error {
-// 				panic("mock out the Create method")
-// 			},
-// 			GetFunc: func(ctx context.Context, id KeyImpl) (bool, error) {
-// 				panic("mock out the Get method")
-// 			},
-// 		}
+//		// make and configure a mocked AliasStore
+//		mockedAliasStore := &AliasStoreMock{
+//			CreateFunc: func(ctx context.Context, id KeyImpl, value bool) error {
+//				panic("mock out the Create method")
+//			},
+//			GetFunc: func(ctx context.Context, id KeyImpl) (bool, error) {
+//				panic("mock out the Get method")
+//			},
+//		}
 //
-// 		// use mockedAliasStore in code that requires AliasStore
-// 		// and then make assertions.
+//		// use mockedAliasStore in code that requires AliasStore
+//		// and then make assertions.
 //
-// 	}
+//	}
 type AliasStoreMock struct {
 	// CreateFunc mocks the Create method.
 	CreateFunc func(ctx context.Context, id KeyImpl, value bool) error
@@ -334,7 +338,8 @@ func (mock *AliasStoreMock) Create(ctx context.Context, id KeyImpl, value bool) 
 
 // CreateCalls gets all the calls that were made to Create.
 // Check the length with:
-//     len(mockedAliasStore.CreateCalls())
+//
+//	len(mockedAliasStore.CreateCalls())
 func (mock *AliasStoreMock) CreateCalls() []struct {
 	Ctx   context.Context
 	ID    KeyImpl
@@ -371,7 +376,8 @@ func (mock *AliasStoreMock) Get(ctx context.Context, id KeyImpl) (bool, error) {
 
 // GetCalls gets all the calls that were made to Get.
 // Check the length with:
-//     len(mockedAliasStore.GetCalls())
+//
+//	len(mockedAliasStore.GetCalls())
 func (mock *AliasStoreMock) GetCalls() []struct {
 	Ctx context.Context
 	ID  KeyImpl

--- a/pkg/moq/testpackages/genparamname/iface_moq.golden.go
+++ b/pkg/moq/testpackages/genparamname/iface_moq.golden.go
@@ -21,19 +21,19 @@ var _ Interface = &InterfaceMock{}
 
 // InterfaceMock is a mock implementation of Interface.
 //
-// 	func TestSomethingThatUsesInterface(t *testing.T) {
+//	func TestSomethingThatUsesInterface(t *testing.T) {
 //
-// 		// make and configure a mocked Interface
-// 		mockedInterface := &InterfaceMock{
-// 			MethodFunc: func(myTypeMoqParam *myType, numbers [3]json.Number, bytes []byte, nullStringToReader map[sql.NullString]io.Reader, fn func(conn net.Conn), goMoqParam Go, bufferPoolCh chan *httputil.BufferPool, val struct{URL *url.URL}, ifaceVal interface{CookieJar() http.CookieJar; fmt.Stringer})  {
-// 				panic("mock out the Method method")
-// 			},
-// 		}
+//		// make and configure a mocked Interface
+//		mockedInterface := &InterfaceMock{
+//			MethodFunc: func(myTypeMoqParam *myType, numbers [3]json.Number, bytes []byte, nullStringToReader map[sql.NullString]io.Reader, fn func(conn net.Conn), goMoqParam Go, bufferPoolCh chan *httputil.BufferPool, val struct{URL *url.URL}, ifaceVal interface{CookieJar() http.CookieJar; fmt.Stringer})  {
+//				panic("mock out the Method method")
+//			},
+//		}
 //
-// 		// use mockedInterface in code that requires Interface
-// 		// and then make assertions.
+//		// use mockedInterface in code that requires Interface
+//		// and then make assertions.
 //
-// 	}
+//	}
 type InterfaceMock struct {
 	// MethodFunc mocks the Method method.
 	MethodFunc func(myTypeMoqParam *myType, numbers [3]json.Number, bytes []byte, nullStringToReader map[sql.NullString]io.Reader, fn func(conn net.Conn), goMoqParam Go, bufferPoolCh chan *httputil.BufferPool, val struct{ URL *url.URL }, ifaceVal interface {
@@ -111,7 +111,8 @@ func (mock *InterfaceMock) Method(myTypeMoqParam *myType, numbers [3]json.Number
 
 // MethodCalls gets all the calls that were made to Method.
 // Check the length with:
-//     len(mockedInterface.MethodCalls())
+//
+//	len(mockedInterface.MethodCalls())
 func (mock *InterfaceMock) MethodCalls() []struct {
 	MyTypeMoqParam     *myType
 	Numbers            [3]json.Number

--- a/pkg/moq/testpackages/gogenvendoring/user/user_moq_test.go
+++ b/pkg/moq/testpackages/gogenvendoring/user/user_moq_test.go
@@ -14,19 +14,19 @@ var _ Service = &ServiceMock{}
 
 // ServiceMock is a mock implementation of Service.
 //
-// 	func TestSomethingThatUsesService(t *testing.T) {
+//	func TestSomethingThatUsesService(t *testing.T) {
 //
-// 		// make and configure a mocked Service
-// 		mockedService := &ServiceMock{
-// 			DoSomethingFunc: func(someType somerepo.SomeType) error {
-// 				panic("mock out the DoSomething method")
-// 			},
-// 		}
+//		// make and configure a mocked Service
+//		mockedService := &ServiceMock{
+//			DoSomethingFunc: func(someType somerepo.SomeType) error {
+//				panic("mock out the DoSomething method")
+//			},
+//		}
 //
-// 		// use mockedService in code that requires Service
-// 		// and then make assertions.
+//		// use mockedService in code that requires Service
+//		// and then make assertions.
 //
-// 	}
+//	}
 type ServiceMock struct {
 	// DoSomethingFunc mocks the DoSomething method.
 	DoSomethingFunc func(someType somerepo.SomeType) error
@@ -60,7 +60,8 @@ func (mock *ServiceMock) DoSomething(someType somerepo.SomeType) error {
 
 // DoSomethingCalls gets all the calls that were made to DoSomething.
 // Check the length with:
-//     len(mockedService.DoSomethingCalls())
+//
+//	len(mockedService.DoSomethingCalls())
 func (mock *ServiceMock) DoSomethingCalls() []struct {
 	SomeType somerepo.SomeType
 } {

--- a/pkg/moq/testpackages/importalias/middleman_moq.golden.go
+++ b/pkg/moq/testpackages/importalias/middleman_moq.golden.go
@@ -15,19 +15,19 @@ var _ MiddleMan = &MiddleManMock{}
 
 // MiddleManMock is a mock implementation of MiddleMan.
 //
-// 	func TestSomethingThatUsesMiddleMan(t *testing.T) {
+//	func TestSomethingThatUsesMiddleMan(t *testing.T) {
 //
-// 		// make and configure a mocked MiddleMan
-// 		mockedMiddleMan := &MiddleManMock{
-// 			ConnectFunc: func(src srcclient.Client, tgt tgtclient.Client)  {
-// 				panic("mock out the Connect method")
-// 			},
-// 		}
+//		// make and configure a mocked MiddleMan
+//		mockedMiddleMan := &MiddleManMock{
+//			ConnectFunc: func(src srcclient.Client, tgt tgtclient.Client)  {
+//				panic("mock out the Connect method")
+//			},
+//		}
 //
-// 		// use mockedMiddleMan in code that requires MiddleMan
-// 		// and then make assertions.
+//		// use mockedMiddleMan in code that requires MiddleMan
+//		// and then make assertions.
 //
-// 	}
+//	}
 type MiddleManMock struct {
 	// ConnectFunc mocks the Connect method.
 	ConnectFunc func(src srcclient.Client, tgt tgtclient.Client)
@@ -65,7 +65,8 @@ func (mock *MiddleManMock) Connect(src srcclient.Client, tgt tgtclient.Client) {
 
 // ConnectCalls gets all the calls that were made to Connect.
 // Check the length with:
-//     len(mockedMiddleMan.ConnectCalls())
+//
+//	len(mockedMiddleMan.ConnectCalls())
 func (mock *MiddleManMock) ConnectCalls() []struct {
 	Src srcclient.Client
 	Tgt tgtclient.Client

--- a/pkg/moq/testpackages/imports/two/gofmt.golden.go
+++ b/pkg/moq/testpackages/imports/two/gofmt.golden.go
@@ -14,22 +14,22 @@ var _ DoSomething = &gofmtMock{}
 
 // gofmtMock is a mock implementation of DoSomething.
 //
-// 	func TestSomethingThatUsesDoSomething(t *testing.T) {
+//	func TestSomethingThatUsesDoSomething(t *testing.T) {
 //
-// 		// make and configure a mocked DoSomething
-// 		mockedDoSomething := &gofmtMock{
-// 			AnotherFunc: func(thing one.Thing) error {
-// 				panic("mock out the Another method")
-// 			},
-// 			DoFunc: func(thing one.Thing) error {
-// 				panic("mock out the Do method")
-// 			},
-// 		}
+//		// make and configure a mocked DoSomething
+//		mockedDoSomething := &gofmtMock{
+//			AnotherFunc: func(thing one.Thing) error {
+//				panic("mock out the Another method")
+//			},
+//			DoFunc: func(thing one.Thing) error {
+//				panic("mock out the Do method")
+//			},
+//		}
 //
-// 		// use mockedDoSomething in code that requires DoSomething
-// 		// and then make assertions.
+//		// use mockedDoSomething in code that requires DoSomething
+//		// and then make assertions.
 //
-// 	}
+//	}
 type gofmtMock struct {
 	// AnotherFunc mocks the Another method.
 	AnotherFunc func(thing one.Thing) error
@@ -72,7 +72,8 @@ func (mock *gofmtMock) Another(thing one.Thing) error {
 
 // AnotherCalls gets all the calls that were made to Another.
 // Check the length with:
-//     len(mockedDoSomething.AnotherCalls())
+//
+//	len(mockedDoSomething.AnotherCalls())
 func (mock *gofmtMock) AnotherCalls() []struct {
 	Thing one.Thing
 } {
@@ -103,7 +104,8 @@ func (mock *gofmtMock) Do(thing one.Thing) error {
 
 // DoCalls gets all the calls that were made to Do.
 // Check the length with:
-//     len(mockedDoSomething.DoCalls())
+//
+//	len(mockedDoSomething.DoCalls())
 func (mock *gofmtMock) DoCalls() []struct {
 	Thing one.Thing
 } {

--- a/pkg/moq/testpackages/imports/two/goimports.golden.go
+++ b/pkg/moq/testpackages/imports/two/goimports.golden.go
@@ -15,22 +15,22 @@ var _ DoSomething = &goimportsMock{}
 
 // goimportsMock is a mock implementation of DoSomething.
 //
-// 	func TestSomethingThatUsesDoSomething(t *testing.T) {
+//	func TestSomethingThatUsesDoSomething(t *testing.T) {
 //
-// 		// make and configure a mocked DoSomething
-// 		mockedDoSomething := &goimportsMock{
-// 			AnotherFunc: func(thing one.Thing) error {
-// 				panic("mock out the Another method")
-// 			},
-// 			DoFunc: func(thing one.Thing) error {
-// 				panic("mock out the Do method")
-// 			},
-// 		}
+//		// make and configure a mocked DoSomething
+//		mockedDoSomething := &goimportsMock{
+//			AnotherFunc: func(thing one.Thing) error {
+//				panic("mock out the Another method")
+//			},
+//			DoFunc: func(thing one.Thing) error {
+//				panic("mock out the Do method")
+//			},
+//		}
 //
-// 		// use mockedDoSomething in code that requires DoSomething
-// 		// and then make assertions.
+//		// use mockedDoSomething in code that requires DoSomething
+//		// and then make assertions.
 //
-// 	}
+//	}
 type goimportsMock struct {
 	// AnotherFunc mocks the Another method.
 	AnotherFunc func(thing one.Thing) error
@@ -73,7 +73,8 @@ func (mock *goimportsMock) Another(thing one.Thing) error {
 
 // AnotherCalls gets all the calls that were made to Another.
 // Check the length with:
-//     len(mockedDoSomething.AnotherCalls())
+//
+//	len(mockedDoSomething.AnotherCalls())
 func (mock *goimportsMock) AnotherCalls() []struct {
 	Thing one.Thing
 } {
@@ -104,7 +105,8 @@ func (mock *goimportsMock) Do(thing one.Thing) error {
 
 // DoCalls gets all the calls that were made to Do.
 // Check the length with:
-//     len(mockedDoSomething.DoCalls())
+//
+//	len(mockedDoSomething.DoCalls())
 func (mock *goimportsMock) DoCalls() []struct {
 	Thing one.Thing
 } {

--- a/pkg/moq/testpackages/imports/two/noop.golden.go
+++ b/pkg/moq/testpackages/imports/two/noop.golden.go
@@ -14,22 +14,22 @@ var _ DoSomething = &noopMock{}
 
 // noopMock is a mock implementation of DoSomething.
 //
-// 	func TestSomethingThatUsesDoSomething(t *testing.T) {
+//	func TestSomethingThatUsesDoSomething(t *testing.T) {
 //
-// 		// make and configure a mocked DoSomething
-// 		mockedDoSomething := &noopMock{
-// 			AnotherFunc: func(thing one.Thing) error {
-// 				panic("mock out the Another method")
-// 			},
-// 			DoFunc: func(thing one.Thing) error {
-// 				panic("mock out the Do method")
-// 			},
-// 		}
+//		// make and configure a mocked DoSomething
+//		mockedDoSomething := &noopMock{
+//			AnotherFunc: func(thing one.Thing) error {
+//				panic("mock out the Another method")
+//			},
+//			DoFunc: func(thing one.Thing) error {
+//				panic("mock out the Do method")
+//			},
+//		}
 //
-// 		// use mockedDoSomething in code that requires DoSomething
-// 		// and then make assertions.
+//		// use mockedDoSomething in code that requires DoSomething
+//		// and then make assertions.
 //
-// 	}
+//	}
 type noopMock struct {
 	// AnotherFunc mocks the Another method.
 	AnotherFunc func(thing one.Thing) error
@@ -72,7 +72,8 @@ func (mock *noopMock) Another(thing one.Thing) error {
 
 // AnotherCalls gets all the calls that were made to Another.
 // Check the length with:
-//     len(mockedDoSomething.AnotherCalls())
+//
+//	len(mockedDoSomething.AnotherCalls())
 func (mock *noopMock) AnotherCalls() []struct {
 		Thing one.Thing
 	} {
@@ -103,7 +104,8 @@ func (mock *noopMock) Do(thing one.Thing) error {
 
 // DoCalls gets all the calls that were made to Do.
 // Check the length with:
-//     len(mockedDoSomething.DoCalls())
+//
+//	len(mockedDoSomething.DoCalls())
 func (mock *noopMock) DoCalls() []struct {
 		Thing one.Thing
 	} {

--- a/pkg/moq/testpackages/paramconflict/iface_moq.golden.go
+++ b/pkg/moq/testpackages/paramconflict/iface_moq.golden.go
@@ -14,19 +14,19 @@ var _ Interface = &InterfaceMock{}
 
 // InterfaceMock is a mock implementation of Interface.
 //
-// 	func TestSomethingThatUsesInterface(t *testing.T) {
+//	func TestSomethingThatUsesInterface(t *testing.T) {
 //
-// 		// make and configure a mocked Interface
-// 		mockedInterface := &InterfaceMock{
-// 			MethodFunc: func(s1 string, b1 bool, s2 string, b2 bool, n1 int, n2 int32, n3 int64, f1 float32, f2 float64, timeMoqParam1 time.Time, timeMoqParam2 time.Time)  {
-// 				panic("mock out the Method method")
-// 			},
-// 		}
+//		// make and configure a mocked Interface
+//		mockedInterface := &InterfaceMock{
+//			MethodFunc: func(s1 string, b1 bool, s2 string, b2 bool, n1 int, n2 int32, n3 int64, f1 float32, f2 float64, timeMoqParam1 time.Time, timeMoqParam2 time.Time)  {
+//				panic("mock out the Method method")
+//			},
+//		}
 //
-// 		// use mockedInterface in code that requires Interface
-// 		// and then make assertions.
+//		// use mockedInterface in code that requires Interface
+//		// and then make assertions.
 //
-// 	}
+//	}
 type InterfaceMock struct {
 	// MethodFunc mocks the Method method.
 	MethodFunc func(s1 string, b1 bool, s2 string, b2 bool, n1 int, n2 int32, n3 int64, f1 float32, f2 float64, timeMoqParam1 time.Time, timeMoqParam2 time.Time)
@@ -100,7 +100,8 @@ func (mock *InterfaceMock) Method(s1 string, b1 bool, s2 string, b2 bool, n1 int
 
 // MethodCalls gets all the calls that were made to Method.
 // Check the length with:
-//     len(mockedInterface.MethodCalls())
+//
+//	len(mockedInterface.MethodCalls())
 func (mock *InterfaceMock) MethodCalls() []struct {
 	S1            string
 	B1            bool

--- a/pkg/moq/testpackages/shadow/mock/thing_moq.golden.go
+++ b/pkg/moq/testpackages/shadow/mock/thing_moq.golden.go
@@ -15,19 +15,19 @@ var _ shadowhttp.Thing = &ThingMock{}
 
 // ThingMock is a mock implementation of shadowhttp.Thing.
 //
-// 	func TestSomethingThatUsesThing(t *testing.T) {
+//	func TestSomethingThatUsesThing(t *testing.T) {
 //
-// 		// make and configure a mocked shadowhttp.Thing
-// 		mockedThing := &ThingMock{
-// 			BlahFunc: func(w nethttp.ResponseWriter, r *nethttp.Request)  {
-// 				panic("mock out the Blah method")
-// 			},
-// 		}
+//		// make and configure a mocked shadowhttp.Thing
+//		mockedThing := &ThingMock{
+//			BlahFunc: func(w nethttp.ResponseWriter, r *nethttp.Request)  {
+//				panic("mock out the Blah method")
+//			},
+//		}
 //
-// 		// use mockedThing in code that requires shadowhttp.Thing
-// 		// and then make assertions.
+//		// use mockedThing in code that requires shadowhttp.Thing
+//		// and then make assertions.
 //
-// 	}
+//	}
 type ThingMock struct {
 	// BlahFunc mocks the Blah method.
 	BlahFunc func(w nethttp.ResponseWriter, r *nethttp.Request)
@@ -65,7 +65,8 @@ func (mock *ThingMock) Blah(w nethttp.ResponseWriter, r *nethttp.Request) {
 
 // BlahCalls gets all the calls that were made to Blah.
 // Check the length with:
-//     len(mockedThing.BlahCalls())
+//
+//	len(mockedThing.BlahCalls())
 func (mock *ThingMock) BlahCalls() []struct {
 	W nethttp.ResponseWriter
 	R *nethttp.Request

--- a/pkg/moq/testpackages/shadow/shadower_moq.golden.go
+++ b/pkg/moq/testpackages/shadow/shadower_moq.golden.go
@@ -15,25 +15,25 @@ var _ Shadower = &ShadowerMock{}
 
 // ShadowerMock is a mock implementation of Shadower.
 //
-// 	func TestSomethingThatUsesShadower(t *testing.T) {
+//	func TestSomethingThatUsesShadower(t *testing.T) {
 //
-// 		// make and configure a mocked Shadower
-// 		mockedShadower := &ShadowerMock{
-// 			ShadowFunc: func(ioMoqParam io.Reader)  {
-// 				panic("mock out the Shadow method")
-// 			},
-// 			ShadowThreeFunc: func(httpMoqParam interface{}, srv *http.Server)  {
-// 				panic("mock out the ShadowThree method")
-// 			},
-// 			ShadowTwoFunc: func(r io.Reader, ioMoqParam interface{})  {
-// 				panic("mock out the ShadowTwo method")
-// 			},
-// 		}
+//		// make and configure a mocked Shadower
+//		mockedShadower := &ShadowerMock{
+//			ShadowFunc: func(ioMoqParam io.Reader)  {
+//				panic("mock out the Shadow method")
+//			},
+//			ShadowThreeFunc: func(httpMoqParam interface{}, srv *http.Server)  {
+//				panic("mock out the ShadowThree method")
+//			},
+//			ShadowTwoFunc: func(r io.Reader, ioMoqParam interface{})  {
+//				panic("mock out the ShadowTwo method")
+//			},
+//		}
 //
-// 		// use mockedShadower in code that requires Shadower
-// 		// and then make assertions.
+//		// use mockedShadower in code that requires Shadower
+//		// and then make assertions.
 //
-// 	}
+//	}
 type ShadowerMock struct {
 	// ShadowFunc mocks the Shadow method.
 	ShadowFunc func(ioMoqParam io.Reader)
@@ -89,7 +89,8 @@ func (mock *ShadowerMock) Shadow(ioMoqParam io.Reader) {
 
 // ShadowCalls gets all the calls that were made to Shadow.
 // Check the length with:
-//     len(mockedShadower.ShadowCalls())
+//
+//	len(mockedShadower.ShadowCalls())
 func (mock *ShadowerMock) ShadowCalls() []struct {
 	IoMoqParam io.Reader
 } {
@@ -122,7 +123,8 @@ func (mock *ShadowerMock) ShadowThree(httpMoqParam interface{}, srv *http.Server
 
 // ShadowThreeCalls gets all the calls that were made to ShadowThree.
 // Check the length with:
-//     len(mockedShadower.ShadowThreeCalls())
+//
+//	len(mockedShadower.ShadowThreeCalls())
 func (mock *ShadowerMock) ShadowThreeCalls() []struct {
 	HttpMoqParam interface{}
 	Srv          *http.Server
@@ -157,7 +159,8 @@ func (mock *ShadowerMock) ShadowTwo(r io.Reader, ioMoqParam interface{}) {
 
 // ShadowTwoCalls gets all the calls that were made to ShadowTwo.
 // Check the length with:
-//     len(mockedShadower.ShadowTwoCalls())
+//
+//	len(mockedShadower.ShadowTwoCalls())
 func (mock *ShadowerMock) ShadowTwoCalls() []struct {
 	R          io.Reader
 	IoMoqParam interface{}

--- a/pkg/moq/testpackages/shadowtypes/shadowtypes_moq.golden.go
+++ b/pkg/moq/testpackages/shadowtypes/shadowtypes_moq.golden.go
@@ -14,73 +14,73 @@ var _ ShadowTypes = &ShadowTypesMock{}
 
 // ShadowTypesMock is a mock implementation of ShadowTypes.
 //
-// 	func TestSomethingThatUsesShadowTypes(t *testing.T) {
+//	func TestSomethingThatUsesShadowTypes(t *testing.T) {
 //
-// 		// make and configure a mocked ShadowTypes
-// 		mockedShadowTypes := &ShadowTypesMock{
-// 			ShadowBoolFunc: func(b bool, boolMoqParam types.Bool)  {
-// 				panic("mock out the ShadowBool method")
-// 			},
-// 			ShadowByteFunc: func(v byte, byteMoqParam types.Byte)  {
-// 				panic("mock out the ShadowByte method")
-// 			},
-// 			ShadowComplex128Func: func(v complex128, complex128MoqParam types.Complex128)  {
-// 				panic("mock out the ShadowComplex128 method")
-// 			},
-// 			ShadowComplex64Func: func(v complex64, complex64MoqParam types.Complex64)  {
-// 				panic("mock out the ShadowComplex64 method")
-// 			},
-// 			ShadowFloat32Func: func(f float32, float32MoqParam types.Float32)  {
-// 				panic("mock out the ShadowFloat32 method")
-// 			},
-// 			ShadowFloat64Func: func(f float64, float64MoqParam types.Float64)  {
-// 				panic("mock out the ShadowFloat64 method")
-// 			},
-// 			ShadowIntFunc: func(n int, intMoqParam types.Int)  {
-// 				panic("mock out the ShadowInt method")
-// 			},
-// 			ShadowInt16Func: func(n int16, int16MoqParam types.Int16)  {
-// 				panic("mock out the ShadowInt16 method")
-// 			},
-// 			ShadowInt32Func: func(n int32, int32MoqParam types.Int32)  {
-// 				panic("mock out the ShadowInt32 method")
-// 			},
-// 			ShadowInt64Func: func(n int64, int64MoqParam types.Int64)  {
-// 				panic("mock out the ShadowInt64 method")
-// 			},
-// 			ShadowInt8Func: func(n int8, int8MoqParam types.Int8)  {
-// 				panic("mock out the ShadowInt8 method")
-// 			},
-// 			ShadowRuneFunc: func(n rune, runeMoqParam types.Rune)  {
-// 				panic("mock out the ShadowRune method")
-// 			},
-// 			ShadowStringFunc: func(s string, stringMoqParam types.String)  {
-// 				panic("mock out the ShadowString method")
-// 			},
-// 			ShadowUintFunc: func(v uint, uintMoqParam types.Uint)  {
-// 				panic("mock out the ShadowUint method")
-// 			},
-// 			ShadowUint16Func: func(v uint16, uint16MoqParam types.Uint16)  {
-// 				panic("mock out the ShadowUint16 method")
-// 			},
-// 			ShadowUint32Func: func(v uint32, uint32MoqParam types.Uint32)  {
-// 				panic("mock out the ShadowUint32 method")
-// 			},
-// 			ShadowUint64Func: func(v uint64, uint64MoqParam types.Uint64)  {
-// 				panic("mock out the ShadowUint64 method")
-// 			},
-// 			ShadowUint8Func: func(v uint8, uint8MoqParam types.Uint8)  {
-// 				panic("mock out the ShadowUint8 method")
-// 			},
-// 			ShadowUintptrFunc: func(v uintptr, uintptrMoqParam types.Uintptr)  {
-// 				panic("mock out the ShadowUintptr method")
-// 			},
-// 		}
+//		// make and configure a mocked ShadowTypes
+//		mockedShadowTypes := &ShadowTypesMock{
+//			ShadowBoolFunc: func(b bool, boolMoqParam types.Bool)  {
+//				panic("mock out the ShadowBool method")
+//			},
+//			ShadowByteFunc: func(v byte, byteMoqParam types.Byte)  {
+//				panic("mock out the ShadowByte method")
+//			},
+//			ShadowComplex128Func: func(v complex128, complex128MoqParam types.Complex128)  {
+//				panic("mock out the ShadowComplex128 method")
+//			},
+//			ShadowComplex64Func: func(v complex64, complex64MoqParam types.Complex64)  {
+//				panic("mock out the ShadowComplex64 method")
+//			},
+//			ShadowFloat32Func: func(f float32, float32MoqParam types.Float32)  {
+//				panic("mock out the ShadowFloat32 method")
+//			},
+//			ShadowFloat64Func: func(f float64, float64MoqParam types.Float64)  {
+//				panic("mock out the ShadowFloat64 method")
+//			},
+//			ShadowIntFunc: func(n int, intMoqParam types.Int)  {
+//				panic("mock out the ShadowInt method")
+//			},
+//			ShadowInt16Func: func(n int16, int16MoqParam types.Int16)  {
+//				panic("mock out the ShadowInt16 method")
+//			},
+//			ShadowInt32Func: func(n int32, int32MoqParam types.Int32)  {
+//				panic("mock out the ShadowInt32 method")
+//			},
+//			ShadowInt64Func: func(n int64, int64MoqParam types.Int64)  {
+//				panic("mock out the ShadowInt64 method")
+//			},
+//			ShadowInt8Func: func(n int8, int8MoqParam types.Int8)  {
+//				panic("mock out the ShadowInt8 method")
+//			},
+//			ShadowRuneFunc: func(n rune, runeMoqParam types.Rune)  {
+//				panic("mock out the ShadowRune method")
+//			},
+//			ShadowStringFunc: func(s string, stringMoqParam types.String)  {
+//				panic("mock out the ShadowString method")
+//			},
+//			ShadowUintFunc: func(v uint, uintMoqParam types.Uint)  {
+//				panic("mock out the ShadowUint method")
+//			},
+//			ShadowUint16Func: func(v uint16, uint16MoqParam types.Uint16)  {
+//				panic("mock out the ShadowUint16 method")
+//			},
+//			ShadowUint32Func: func(v uint32, uint32MoqParam types.Uint32)  {
+//				panic("mock out the ShadowUint32 method")
+//			},
+//			ShadowUint64Func: func(v uint64, uint64MoqParam types.Uint64)  {
+//				panic("mock out the ShadowUint64 method")
+//			},
+//			ShadowUint8Func: func(v uint8, uint8MoqParam types.Uint8)  {
+//				panic("mock out the ShadowUint8 method")
+//			},
+//			ShadowUintptrFunc: func(v uintptr, uintptrMoqParam types.Uintptr)  {
+//				panic("mock out the ShadowUintptr method")
+//			},
+//		}
 //
-// 		// use mockedShadowTypes in code that requires ShadowTypes
-// 		// and then make assertions.
+//		// use mockedShadowTypes in code that requires ShadowTypes
+//		// and then make assertions.
 //
-// 	}
+//	}
 type ShadowTypesMock struct {
 	// ShadowBoolFunc mocks the ShadowBool method.
 	ShadowBoolFunc func(b bool, boolMoqParam types.Bool)
@@ -316,7 +316,8 @@ func (mock *ShadowTypesMock) ShadowBool(b bool, boolMoqParam types.Bool) {
 
 // ShadowBoolCalls gets all the calls that were made to ShadowBool.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowBoolCalls())
+//
+//	len(mockedShadowTypes.ShadowBoolCalls())
 func (mock *ShadowTypesMock) ShadowBoolCalls() []struct {
 	B            bool
 	BoolMoqParam types.Bool
@@ -351,7 +352,8 @@ func (mock *ShadowTypesMock) ShadowByte(v byte, byteMoqParam types.Byte) {
 
 // ShadowByteCalls gets all the calls that were made to ShadowByte.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowByteCalls())
+//
+//	len(mockedShadowTypes.ShadowByteCalls())
 func (mock *ShadowTypesMock) ShadowByteCalls() []struct {
 	V            byte
 	ByteMoqParam types.Byte
@@ -386,7 +388,8 @@ func (mock *ShadowTypesMock) ShadowComplex128(v complex128, complex128MoqParam t
 
 // ShadowComplex128Calls gets all the calls that were made to ShadowComplex128.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowComplex128Calls())
+//
+//	len(mockedShadowTypes.ShadowComplex128Calls())
 func (mock *ShadowTypesMock) ShadowComplex128Calls() []struct {
 	V                  complex128
 	Complex128MoqParam types.Complex128
@@ -421,7 +424,8 @@ func (mock *ShadowTypesMock) ShadowComplex64(v complex64, complex64MoqParam type
 
 // ShadowComplex64Calls gets all the calls that were made to ShadowComplex64.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowComplex64Calls())
+//
+//	len(mockedShadowTypes.ShadowComplex64Calls())
 func (mock *ShadowTypesMock) ShadowComplex64Calls() []struct {
 	V                 complex64
 	Complex64MoqParam types.Complex64
@@ -456,7 +460,8 @@ func (mock *ShadowTypesMock) ShadowFloat32(f float32, float32MoqParam types.Floa
 
 // ShadowFloat32Calls gets all the calls that were made to ShadowFloat32.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowFloat32Calls())
+//
+//	len(mockedShadowTypes.ShadowFloat32Calls())
 func (mock *ShadowTypesMock) ShadowFloat32Calls() []struct {
 	F               float32
 	Float32MoqParam types.Float32
@@ -491,7 +496,8 @@ func (mock *ShadowTypesMock) ShadowFloat64(f float64, float64MoqParam types.Floa
 
 // ShadowFloat64Calls gets all the calls that were made to ShadowFloat64.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowFloat64Calls())
+//
+//	len(mockedShadowTypes.ShadowFloat64Calls())
 func (mock *ShadowTypesMock) ShadowFloat64Calls() []struct {
 	F               float64
 	Float64MoqParam types.Float64
@@ -526,7 +532,8 @@ func (mock *ShadowTypesMock) ShadowInt(n int, intMoqParam types.Int) {
 
 // ShadowIntCalls gets all the calls that were made to ShadowInt.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowIntCalls())
+//
+//	len(mockedShadowTypes.ShadowIntCalls())
 func (mock *ShadowTypesMock) ShadowIntCalls() []struct {
 	N           int
 	IntMoqParam types.Int
@@ -561,7 +568,8 @@ func (mock *ShadowTypesMock) ShadowInt16(n int16, int16MoqParam types.Int16) {
 
 // ShadowInt16Calls gets all the calls that were made to ShadowInt16.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowInt16Calls())
+//
+//	len(mockedShadowTypes.ShadowInt16Calls())
 func (mock *ShadowTypesMock) ShadowInt16Calls() []struct {
 	N             int16
 	Int16MoqParam types.Int16
@@ -596,7 +604,8 @@ func (mock *ShadowTypesMock) ShadowInt32(n int32, int32MoqParam types.Int32) {
 
 // ShadowInt32Calls gets all the calls that were made to ShadowInt32.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowInt32Calls())
+//
+//	len(mockedShadowTypes.ShadowInt32Calls())
 func (mock *ShadowTypesMock) ShadowInt32Calls() []struct {
 	N             int32
 	Int32MoqParam types.Int32
@@ -631,7 +640,8 @@ func (mock *ShadowTypesMock) ShadowInt64(n int64, int64MoqParam types.Int64) {
 
 // ShadowInt64Calls gets all the calls that were made to ShadowInt64.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowInt64Calls())
+//
+//	len(mockedShadowTypes.ShadowInt64Calls())
 func (mock *ShadowTypesMock) ShadowInt64Calls() []struct {
 	N             int64
 	Int64MoqParam types.Int64
@@ -666,7 +676,8 @@ func (mock *ShadowTypesMock) ShadowInt8(n int8, int8MoqParam types.Int8) {
 
 // ShadowInt8Calls gets all the calls that were made to ShadowInt8.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowInt8Calls())
+//
+//	len(mockedShadowTypes.ShadowInt8Calls())
 func (mock *ShadowTypesMock) ShadowInt8Calls() []struct {
 	N            int8
 	Int8MoqParam types.Int8
@@ -701,7 +712,8 @@ func (mock *ShadowTypesMock) ShadowRune(n rune, runeMoqParam types.Rune) {
 
 // ShadowRuneCalls gets all the calls that were made to ShadowRune.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowRuneCalls())
+//
+//	len(mockedShadowTypes.ShadowRuneCalls())
 func (mock *ShadowTypesMock) ShadowRuneCalls() []struct {
 	N            rune
 	RuneMoqParam types.Rune
@@ -736,7 +748,8 @@ func (mock *ShadowTypesMock) ShadowString(s string, stringMoqParam types.String)
 
 // ShadowStringCalls gets all the calls that were made to ShadowString.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowStringCalls())
+//
+//	len(mockedShadowTypes.ShadowStringCalls())
 func (mock *ShadowTypesMock) ShadowStringCalls() []struct {
 	S              string
 	StringMoqParam types.String
@@ -771,7 +784,8 @@ func (mock *ShadowTypesMock) ShadowUint(v uint, uintMoqParam types.Uint) {
 
 // ShadowUintCalls gets all the calls that were made to ShadowUint.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowUintCalls())
+//
+//	len(mockedShadowTypes.ShadowUintCalls())
 func (mock *ShadowTypesMock) ShadowUintCalls() []struct {
 	V            uint
 	UintMoqParam types.Uint
@@ -806,7 +820,8 @@ func (mock *ShadowTypesMock) ShadowUint16(v uint16, uint16MoqParam types.Uint16)
 
 // ShadowUint16Calls gets all the calls that were made to ShadowUint16.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowUint16Calls())
+//
+//	len(mockedShadowTypes.ShadowUint16Calls())
 func (mock *ShadowTypesMock) ShadowUint16Calls() []struct {
 	V              uint16
 	Uint16MoqParam types.Uint16
@@ -841,7 +856,8 @@ func (mock *ShadowTypesMock) ShadowUint32(v uint32, uint32MoqParam types.Uint32)
 
 // ShadowUint32Calls gets all the calls that were made to ShadowUint32.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowUint32Calls())
+//
+//	len(mockedShadowTypes.ShadowUint32Calls())
 func (mock *ShadowTypesMock) ShadowUint32Calls() []struct {
 	V              uint32
 	Uint32MoqParam types.Uint32
@@ -876,7 +892,8 @@ func (mock *ShadowTypesMock) ShadowUint64(v uint64, uint64MoqParam types.Uint64)
 
 // ShadowUint64Calls gets all the calls that were made to ShadowUint64.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowUint64Calls())
+//
+//	len(mockedShadowTypes.ShadowUint64Calls())
 func (mock *ShadowTypesMock) ShadowUint64Calls() []struct {
 	V              uint64
 	Uint64MoqParam types.Uint64
@@ -911,7 +928,8 @@ func (mock *ShadowTypesMock) ShadowUint8(v uint8, uint8MoqParam types.Uint8) {
 
 // ShadowUint8Calls gets all the calls that were made to ShadowUint8.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowUint8Calls())
+//
+//	len(mockedShadowTypes.ShadowUint8Calls())
 func (mock *ShadowTypesMock) ShadowUint8Calls() []struct {
 	V             uint8
 	Uint8MoqParam types.Uint8
@@ -946,7 +964,8 @@ func (mock *ShadowTypesMock) ShadowUintptr(v uintptr, uintptrMoqParam types.Uint
 
 // ShadowUintptrCalls gets all the calls that were made to ShadowUintptr.
 // Check the length with:
-//     len(mockedShadowTypes.ShadowUintptrCalls())
+//
+//	len(mockedShadowTypes.ShadowUintptrCalls())
 func (mock *ShadowTypesMock) ShadowUintptrCalls() []struct {
 	V               uintptr
 	UintptrMoqParam types.Uintptr

--- a/pkg/moq/testpackages/syncimport/syncer_moq.golden.go
+++ b/pkg/moq/testpackages/syncimport/syncer_moq.golden.go
@@ -14,19 +14,19 @@ var _ Syncer = &SyncerMock{}
 
 // SyncerMock is a mock implementation of Syncer.
 //
-// 	func TestSomethingThatUsesSyncer(t *testing.T) {
+//	func TestSomethingThatUsesSyncer(t *testing.T) {
 //
-// 		// make and configure a mocked Syncer
-// 		mockedSyncer := &SyncerMock{
-// 			BlahFunc: func(s sync.Thing, wg *stdsync.WaitGroup)  {
-// 				panic("mock out the Blah method")
-// 			},
-// 		}
+//		// make and configure a mocked Syncer
+//		mockedSyncer := &SyncerMock{
+//			BlahFunc: func(s sync.Thing, wg *stdsync.WaitGroup)  {
+//				panic("mock out the Blah method")
+//			},
+//		}
 //
-// 		// use mockedSyncer in code that requires Syncer
-// 		// and then make assertions.
+//		// use mockedSyncer in code that requires Syncer
+//		// and then make assertions.
 //
-// 	}
+//	}
 type SyncerMock struct {
 	// BlahFunc mocks the Blah method.
 	BlahFunc func(s sync.Thing, wg *stdsync.WaitGroup)
@@ -64,7 +64,8 @@ func (mock *SyncerMock) Blah(s sync.Thing, wg *stdsync.WaitGroup) {
 
 // BlahCalls gets all the calls that were made to Blah.
 // Check the length with:
-//     len(mockedSyncer.BlahCalls())
+//
+//	len(mockedSyncer.BlahCalls())
 func (mock *SyncerMock) BlahCalls() []struct {
 	S  sync.Thing
 	Wg *stdsync.WaitGroup

--- a/pkg/moq/testpackages/variadic/echoer.golden.go
+++ b/pkg/moq/testpackages/variadic/echoer.golden.go
@@ -13,19 +13,19 @@ var _ Echoer = &EchoerMock{}
 
 // EchoerMock is a mock implementation of Echoer.
 //
-// 	func TestSomethingThatUsesEchoer(t *testing.T) {
+//	func TestSomethingThatUsesEchoer(t *testing.T) {
 //
-// 		// make and configure a mocked Echoer
-// 		mockedEchoer := &EchoerMock{
-// 			EchoFunc: func(ss ...string) []string {
-// 				panic("mock out the Echo method")
-// 			},
-// 		}
+//		// make and configure a mocked Echoer
+//		mockedEchoer := &EchoerMock{
+//			EchoFunc: func(ss ...string) []string {
+//				panic("mock out the Echo method")
+//			},
+//		}
 //
-// 		// use mockedEchoer in code that requires Echoer
-// 		// and then make assertions.
+//		// use mockedEchoer in code that requires Echoer
+//		// and then make assertions.
 //
-// 	}
+//	}
 type EchoerMock struct {
 	// EchoFunc mocks the Echo method.
 	EchoFunc func(ss ...string) []string
@@ -59,7 +59,8 @@ func (mock *EchoerMock) Echo(ss ...string) []string {
 
 // EchoCalls gets all the calls that were made to Echo.
 // Check the length with:
-//     len(mockedEchoer.EchoCalls())
+//
+//	len(mockedEchoer.EchoCalls())
 func (mock *EchoerMock) EchoCalls() []struct {
 	Ss []string
 } {


### PR DESCRIPTION
- Only test on 1.19 for Windows and Mac.
- Bump versions for checkout and setup-go actions. Use cache flag in 
  setup-go instead of separate cache step.