### PR TITLE
Do not load unnecessary package information

### DIFF
--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,13 @@
+package registry_test
+
+import (
+	"testing"
+
+	"github.com/matryer/moq/internal/registry"
+)
+
+func BenchmarkNew(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		registry.New("../../pkg/moq/testpackages/example", "")
+	}
+}


### PR DESCRIPTION
This merge request is a performance improvement to address #178. The merge request contains two commits, in which the first commit adds a benchmark test. This allows the benchmark test to be executed before and after the changes in the second commit for comparison. Further optimization may be required to close #178, but I hope that this merge request is a step in the right direction.

The following are the benchmark results on my dev machine:

Before:

```
$ go test -bench=. ./internal/registry -count 3
goos: linux
goarch: amd64
pkg: github.com/matryer/moq/internal/registry
cpu: Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz
BenchmarkNew-8                 3         335638233 ns/op
BenchmarkNew-8                 4         328678100 ns/op
BenchmarkNew-8                 4         322492350 ns/op
PASS
ok      github.com/matryer/moq/internal/registry        8.735s
```

After:

```
go test -bench=. ./internal/registry -count 3
goos: linux
goarch: amd64
pkg: github.com/matryer/moq/internal/registry
cpu: Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz
BenchmarkNew-8                15          76012420 ns/op
BenchmarkNew-8                14          76392171 ns/op
BenchmarkNew-8                14          76113471 ns/op
PASS
ok      github.com/matryer/moq/internal/registry        3.520s
```

The following shows an approximate time improvement to execute all tests on my dev machine:

Before:

```
go clean -testcache && time go test ./...
?       github.com/matryer/moq  [no test files]
?       github.com/matryer/moq/generate [no test files]
ok      github.com/matryer/moq/example  0.002s [no tests to run]
ok      github.com/matryer/moq/internal/registry        0.002s [no tests to run]
ok      github.com/matryer/moq/internal/template        0.002s
ok      github.com/matryer/moq/pkg/moq  11.691s

real    0m17.944s
user    0m28.584s
sys     0m3.847s
```

After:

```
$ go clean -testcache && time go test ./...
?       github.com/matryer/moq  [no test files]
?       github.com/matryer/moq/generate [no test files]
ok      github.com/matryer/moq/example  0.002s [no tests to run]
ok      github.com/matryer/moq/internal/registry        0.002s [no tests to run]
ok      github.com/matryer/moq/internal/template        0.002s
ok      github.com/matryer/moq/pkg/moq  3.704s

real    0m9.468s
user    0m4.982s
sys     0m2.330s
```