### PR TITLE
Fix stderr not printing in TestGoGenerateVendoredPackages

### DIFF
--- a/pkg/moq/moq_test.go
+++ b/pkg/moq/moq_test.go
@@ -623,21 +623,24 @@ func TestGoGenerateVendoredPackages(t *testing.T) {
 		t.Errorf("StdoutPipe: %s", err)
 	}
 	defer stdout.Close()
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		t.Errorf("StderrPipe: %s", err)
+	}
+	defer stderr.Close()
 	err = cmd.Start()
 	if err != nil {
 		t.Errorf("Start: %s", err)
 	}
-	buf := bytes.NewBuffer(nil)
-	io.Copy(buf, stdout)
+	stdoutBuf := bytes.NewBuffer(nil)
+	io.Copy(stdoutBuf, stdout)
+	stderrBuf := bytes.NewBuffer(nil)
+	io.Copy(stderrBuf, stderr)
 	err = cmd.Wait()
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			t.Errorf("Wait: %s %s", exitErr, string(exitErr.Stderr))
-		} else {
-			t.Errorf("Wait: %s", err)
-		}
+		t.Errorf("Wait: %s %s", err, stderrBuf.String())
 	}
-	s := buf.String()
+	s := stdoutBuf.String()
 	if strings.Contains(s, `vendor/`) {
 		t.Error("contains vendor directory in import path")
 	}


### PR DESCRIPTION
Before this commit, the TestGoGenerateVendoredPackages test failed to print stderr to the terminal as expected. Stderr was not printed because the test expected ExitError.Stderr to be populated. Per documentation [ExitError.Stderr] is only populated by the [Cmd.Output] method, which the test does not use. With this commit, the test uses a buffer to record stderr and include it in the failed test message as previously intended.

This issue was discovered because the TestGoGenerateVendoredPackages test expects moq to be available in the PATH. That means that running tests (go test ./...) in this project without first installing moq (go install) results in the TestGoGenerateVendoredPackages test to fail.

Before this commit, the error message looked as follows:

    --- FAIL: TestGoGenerateVendoredPackages (0.03s)
        moq_test.go:635: Wait: exit status 1

This error message does not include the output from stderr, making it difficult to know why the test is failing.

With this commit, the error message looks as follows:

    --- FAIL: TestGoGenerateVendoredPackages (0.03s)
        moq_test.go:641: Wait: exit status 1 user/user.go:5: running
        "moq": exec: "moq": executable file not found in $PATH

[ExitError.Stderr]: https://pkg.go.dev/os/exec#ExitError
[Cmd.Output]: https://pkg.go.dev/os/exec#Cmd.Output