### PR TITLE
build: bump golang.org/x/tools v0.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,7 @@ go 1.18
 
 require (
 	github.com/pmezard/go-difflib v1.0.0
-	golang.org/x/tools v0.3.0
+	golang.org/x/tools v0.17.0
 )
 
-require (
-	golang.org/x/mod v0.7.0 // indirect
-	golang.org/x/sys v0.2.0 // indirect
-)
+require golang.org/x/mod v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
-golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
-golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
-golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.3.0 h1:SrNbZl6ECOS1qFzgTdQfWXZM9XBkiA6tkFrH9YSTPHM=
-golang.org/x/tools v0.3.0/go.mod h1:/rWhSS2+zyEVwoJf8YAX6L2f0ntZ7Kn/mGgAWcipA5k=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+golang.org/x/tools v0.17.0 h1:FvmRgNOcs3kOa+T20R1uhfP9F6HgG2mfxDv1vrx1Htc=
+golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=


### PR DESCRIPTION
After I update to go `1.22.0`, running moq is panic with `runtime error: invalid memory address or nil pointer dereference`.

Updating `golang.org/x/tools` fix the issue.

My command:

```sh
moq -out ads_mock_generated.go . AdsService
```

The panic:

```txt
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x102eaa670]

goroutine 2295 [running]:
go/types.(*Checker).handleBailout(0x14000264e00, 0x1400003dbe8)
	/usr/local/go/src/go/types/check.go:367 +0x9c
panic({0x1030112c0?, 0x103240b80?})
	/usr/local/go/src/runtime/panic.go:770 +0x124
go/types.(*StdSizes).Sizeof(0x0, {0x103060238, 0x103244500})
	/usr/local/go/src/go/types/sizes.go:228 +0x320
go/types.(*Config).sizeof(...)
	/usr/local/go/src/go/types/sizes.go:333
go/types.representableConst.func1({0x103060238?, 0x103244500?})
	/usr/local/go/src/go/types/const.go:76 +0x9c
go/types.representableConst({0x103061ea8, 0x14000278ef0}, 0x14000264e00, 0x103244500, 0x0)
	/usr/local/go/src/go/types/const.go:92 +0x138
go/types.(*Checker).arrayLength(0x14000264e00, {0x1030616a8, 0x1400027b300?})
	/usr/local/go/src/go/types/typexpr.go:510 +0x238
go/types.(*Checker).typInternal(0x14000264e00, {0x1030617f8, 0x14000ec4780}, 0x0)
	/usr/local/go/src/go/types/typexpr.go:299 +0x3bc
go/types.(*Checker).definedType(0x14000264e00, {0x1030617f8, 0x14000ec4780}, 0x14000ffd3b0?)
	/usr/local/go/src/go/types/typexpr.go:180 +0x2c
go/types.(*Checker).typ(...)
	/usr/local/go/src/go/types/typexpr.go:138
go/types.(*Checker).exprInternal(0x14000264e00, 0x0, 0x14000bef740, {0x103061708, 0x140012d0900}, {0x0, 0x0})
	/usr/local/go/src/go/types/expr.go:1117 +0xc04
go/types.(*Checker).rawExpr(0x14000264e00, 0x0, 0x14000bef740, {0x103061708?, 0x140012d0900?}, {0x0?, 0x0?}, 0x0)
	/usr/local/go/src/go/types/expr.go:979 +0x12c
go/types.(*Checker).expr(0x14000264e00, 0x0?, 0x14000bef740, {0x103061708?, 0x140012d0900?})
	/usr/local/go/src/go/types/expr.go:1513 +0x38
go/types.(*Checker).varDecl(0x14000264e00, 0x140013ba000, {0x14000124758, 0x1, 0x1}, {0x0, 0x0}, {0x103061708, 0x140012d0900})
	/usr/local/go/src/go/types/decl.go:521 +0x140
go/types.(*Checker).objDecl(0x14000264e00, {0x103065498, 0x140013ba000}, 0x0)
	/usr/local/go/src/go/types/decl.go:194 +0x7ec
go/types.(*Checker).packageObjects(0x14000264e00)
	/usr/local/go/src/go/types/resolver.go:693 +0x468
go/types.(*Checker).checkFiles(0x14000264e00, {0x14000124078, 0x1,0x1})
	/usr/local/go/src/go/types/check.go:408 +0x164
go/types.(*Checker).Files(...)
	/usr/local/go/src/go/types/check.go:372
golang.org/x/tools/go/packages.(*loader).loadPackage(0x140001941c0, 0x14000375020)
	/Users/anon/go/pkg/mod/golang.org/x/tools@v0.3.0/go/packages/packages.go:1037 +0x784
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1()
	/Users/anon/go/pkg/mod/golang.org/x/tools@v0.3.0/go/packages/packages.go:847 +0x178
sync.(*Once).doSlow(0x0?, 0x0?)
	/usr/local/go/src/sync/once.go:74 +0x100
sync.(*Once).Do(...)
	/usr/local/go/src/sync/once.go:65
golang.org/x/tools/go/packages.(*loader).loadRecursive(0x0?, 0x0?)
	/Users/anon/go/pkg/mod/golang.org/x/tools@v0.3.0/go/packages/packages.go:835 +0x50
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1.1(0x0?)
	/Users/anon/go/pkg/mod/golang.org/x/tools@v0.3.0/go/packages/packages.go:842 +0x30
created by golang.org/x/tools/go/packages.(*loader).loadRecursive.func1 in goroutine 2049
	/Users/anon/go/pkg/mod/golang.org/x/tools@v0.3.0/go/packages/packages.go:841 +0x84
```

So I make the PR to update `golang.org/x/tools` and fix https://github.com/matryer/moq/issues/212

Again, thanks for wonderful mock tool.