### PR TITLE
.github/test.yml: Run tests on latest supported Go versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.22
           cache: true
           check-latest: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-expanding-configurations
         include:
           - os: windows-latest
-            go-version: 1.22.x
+            go-version: stable
           - os: macos-latest
-            go-version: 1.22.x
+            go-version: stable
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.21.x, 1.22.x]
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-expanding-configurations
         include:
           - os: windows-latest
-            go-version: 1.19.x
+            go-version: 1.22.x
           - os: macos-latest
-            go-version: 1.19.x
+            go-version: 1.22.x
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.21.x, 1.22.x]
+        go-version: [oldstable, stable]
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-expanding-configurations
         include:
           - os: windows-latest


### PR DESCRIPTION
Test for supported Go versions and utilizing the new “stable” and “oldstable” version aliases to avoid having to update this for each successive Go version.