### PR TITLE
build: Update go to 1.24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22
+          go-version: 'stable'
           cache: true
           check-latest: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 'stable'
           cache: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matryer/moq
 
-go 1.23
+go 1.24
 
 require (
 	github.com/pmezard/go-difflib v1.0.0


### PR DESCRIPTION
With go 1.24, `go install github.com/matryer/moq@latest` works but binaries from https://github.com/matryer/moq/releases/tag/v0.5.2 doesn't work.

> package requires newer Go version go1.24 (application built with go1.23)