### PR TITLE
build with go 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matryer/moq
 
-go 1.24
+go 1.25
 
 require (
 	github.com/pmezard/go-difflib v1.0.0


### PR DESCRIPTION
Support Go `1.25`

Closes https://github.com/matryer/moq/issues/237